### PR TITLE
run clippy on tests, fix findings

### DIFF
--- a/.github/workflows/libssl.yaml
+++ b/.github/workflows/libssl.yaml
@@ -117,7 +117,7 @@ jobs:
         # (below) will have a new lint that we want to suppress.
         # If we suppress (e.g. #![allow(clippy::arc_with_non_send_sync)]),
         # we would get an unknown-lint error from older clippy versions.
-        run: cargo clippy --locked --workspace -- -D warnings -A unknown-lints
+        run: cargo clippy --locked --workspace --all-targets -- -D warnings -A unknown-lints
 
   clippy-nightly-optional:
     name: Clippy nightly (optional)
@@ -132,7 +132,7 @@ jobs:
         with:
           components: clippy
       - name: Check clippy
-        run: cargo clippy --locked --workspace -- -D warnings
+        run: cargo clippy --locked --workspace --all-targets -- -D warnings
 
   clang-tidy:
     name: Clang Tidy

--- a/rustls-libssl/Makefile
+++ b/rustls-libssl/Makefile
@@ -22,10 +22,10 @@ endif
 all: target/ciphers target/client target/constants target/$(PROFILE)/libssl.so.3
 
 test: all
-	${CARGO} test --locked
+	${CARGO} test $(CARGOFLAGS)
 
 integration: all
-	${CARGO} test --locked -- --ignored
+	${CARGO} test $(CARGOFLAGS) -- --ignored
 
 target:
 	mkdir -p $@

--- a/rustls-libssl/src/entry.rs
+++ b/rustls-libssl/src/entry.rs
@@ -1143,7 +1143,6 @@ entry_stub! {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use core::ptr;
 
     #[test]
     fn test_SSL_CTX_new_null() {

--- a/rustls-libssl/tests/runner.rs
+++ b/rustls-libssl/tests/runner.rs
@@ -32,7 +32,7 @@ use std::{net, thread, time};
 fn client() {
     let _server = KillOnDrop(
         Command::new("openssl")
-            .args(&[
+            .args([
                 "s_server",
                 "-cert",
                 "test-ca/rsa/end.cert",
@@ -55,14 +55,14 @@ fn client() {
 
     let openssl_insecure_output = Command::new("tests/maybe-valgrind.sh")
         .env("LD_LIBRARY_PATH", "")
-        .args(&["target/client", "localhost", "4443", "insecure"])
+        .args(["target/client", "localhost", "4443", "insecure"])
         .stdout(Stdio::piped())
         .output()
         .map(print_output)
         .unwrap();
 
     let rustls_insecure_output = Command::new("tests/maybe-valgrind.sh")
-        .args(&["target/client", "localhost", "4443", "insecure"])
+        .args(["target/client", "localhost", "4443", "insecure"])
         .stdout(Stdio::piped())
         .output()
         .map(print_output)
@@ -72,14 +72,14 @@ fn client() {
 
     let openssl_secure_output = Command::new("tests/maybe-valgrind.sh")
         .env("LD_LIBRARY_PATH", "")
-        .args(&["target/client", "localhost", "4443", "test-ca/rsa/ca.cert"])
+        .args(["target/client", "localhost", "4443", "test-ca/rsa/ca.cert"])
         .stdout(Stdio::piped())
         .output()
         .map(print_output)
         .unwrap();
 
     let rustls_secure_output = Command::new("tests/maybe-valgrind.sh")
-        .args(&["target/client", "localhost", "4443", "test-ca/rsa/ca.cert"])
+        .args(["target/client", "localhost", "4443", "test-ca/rsa/ca.cert"])
         .stdout(Stdio::piped())
         .output()
         .map(print_output)
@@ -94,7 +94,7 @@ fn client_real_world() {
     let openssl_output = Command::new("tests/maybe-valgrind.sh")
         .env("LD_LIBRARY_PATH", "")
         .env("NO_ECHO", "1")
-        .args(&["target/client", "example.com", "443", "default"])
+        .args(["target/client", "example.com", "443", "default"])
         .stdout(Stdio::piped())
         .output()
         .map(print_output)
@@ -102,7 +102,7 @@ fn client_real_world() {
 
     let rustls_output = Command::new("tests/maybe-valgrind.sh")
         .env("NO_ECHO", "1")
-        .args(&["target/client", "example.com", "443", "default"])
+        .args(["target/client", "example.com", "443", "default"])
         .stdout(Stdio::piped())
         .output()
         .map(print_output)
@@ -115,7 +115,7 @@ fn client_real_world() {
 #[ignore]
 fn constants() {
     let openssl_output = Command::new("tests/maybe-valgrind.sh")
-        .args(&["target/constants"])
+        .args(["target/constants"])
         .env("LD_LIBRARY_PATH", "")
         .stdout(Stdio::piped())
         .output()
@@ -123,7 +123,7 @@ fn constants() {
         .unwrap();
 
     let rustls_output = Command::new("tests/maybe-valgrind.sh")
-        .args(&["target/constants"])
+        .args(["target/constants"])
         .stdout(Stdio::piped())
         .output()
         .map(print_output)
@@ -136,7 +136,7 @@ fn constants() {
 #[ignore]
 fn ciphers() {
     let openssl_output = Command::new("tests/maybe-valgrind.sh")
-        .args(&["target/ciphers"])
+        .args(["target/ciphers"])
         .env("LD_LIBRARY_PATH", "")
         .stdout(Stdio::piped())
         .output()
@@ -144,7 +144,7 @@ fn ciphers() {
         .unwrap();
 
     let rustls_output = Command::new("tests/maybe-valgrind.sh")
-        .args(&["target/ciphers"])
+        .args(["target/ciphers"])
         .stdout(Stdio::piped())
         .output()
         .map(print_output)


### PR DESCRIPTION
Noticed there were some clippy warnings in the CI test output. It looks like rustls-ffi wasn't running clippy on tests and this repo inherited that. I'll fix over there as well but as expected there are a lot more findings to squash. This repo has managed to avoid accruing too many. Let's keep it at zero by adding this to CI.