### PR TITLE
Remove locking

### DIFF
--- a/rustls-libssl/src/error.rs
+++ b/rustls-libssl/src/error.rs
@@ -23,7 +23,6 @@ const ERR_RFLAG_COMMON: i32 = 0x2i32 << ERR_RFLAGS_OFFSET;
 enum Reason {
     PassedNullParameter,
     InternalError,
-    UnableToGetWriteLock,
     OperationFailed,
     Unsupported,
     WouldBlock,
@@ -37,7 +36,6 @@ impl From<Reason> for c_int {
             // see `err.h.in` for magic numbers.
             PassedNullParameter => (ERR_RFLAG_FATAL as i32) | ERR_RFLAG_COMMON | 258,
             InternalError => (ERR_RFLAG_FATAL as i32) | ERR_RFLAG_COMMON | 259,
-            UnableToGetWriteLock => (ERR_RFLAG_FATAL as i32) | ERR_RFLAG_COMMON | 272,
             OperationFailed => (ERR_RFLAG_FATAL as i32) | ERR_RFLAG_COMMON | 263,
             Unsupported => ERR_RFLAG_COMMON | 268,
             WouldBlock => 0,
@@ -67,14 +65,6 @@ impl Error {
         Self {
             lib: Lib::Ssl,
             reason: Reason::PassedNullParameter,
-            string: None,
-        }
-    }
-
-    pub fn cannot_lock() -> Self {
-        Self {
-            lib: Lib::Ssl,
-            reason: Reason::UnableToGetWriteLock,
             string: None,
         }
     }

--- a/rustls-libssl/src/not_thread_safe.rs
+++ b/rustls-libssl/src/not_thread_safe.rs
@@ -1,0 +1,35 @@
+use core::cell::UnsafeCell;
+
+/// An extremely bad and unsafe laundering of pointer-to-references.
+///
+/// OpenSSL's API is specifically not thread-safe.  `SSL_CTX` and `SSL`
+/// instances must not be shared between threads.  See
+/// <https://www.openssl.org/blog/blog/2017/02/21/threads/>
+///
+/// Because the API includes callbacks (that must be called at
+/// specific times, and may have side effects) and those callbacks can
+/// re-enter the API, just having a `Mutex<T>` here is not workable:
+/// `Mutex<T>` is not recursive, and cannot be without being a font of
+/// multiple mutable references onto one object.
+pub struct NotThreadSafe<T> {
+    cell: UnsafeCell<T>,
+}
+
+impl<T> NotThreadSafe<T> {
+    pub fn new(value: T) -> Self {
+        Self {
+            cell: UnsafeCell::new(value),
+        }
+    }
+
+    pub fn get(&self) -> &T {
+        // safety: extremely not
+        unsafe { &*(self.cell.get() as *const T) }
+    }
+
+    #[allow(clippy::mut_from_ref)]
+    pub fn get_mut(&self) -> &mut T {
+        // safety: extremely not
+        unsafe { &mut *self.cell.get() }
+    }
+}


### PR DESCRIPTION
This was the wrong direction: coming commits want to call callbacks (which themselves can and do re-enter the API) which would lead to deadlock.

Let's just accept that the API we're implementing is not thread safe.

I also looked at deferring callbacks to outside the lock scope, but that removes the ability for callbacks to have side effects during the handshake.