### PR TITLE
Backport ASAN build fixes from rustls-ffi

### DIFF
--- a/.github/workflows/libssl.yaml
+++ b/.github/workflows/libssl.yaml
@@ -41,6 +41,20 @@ jobs:
 
       - run: make PROFILE=debug test
       - run: make PROFILE=debug integration
+        # Note: we only check the client/server binaries here, assuming that
+        #       is sufficient for any other test binaries.
+      - name: Verify debug builds were using ASAN
+        run: |
+          nm target/client | grep '__asan_init'
+          nm target/server | grep '__asan_init'
+      - name: Build release binaries
+        run: |
+          make clean
+          make PROFILE=release
+      - name: Verify release builds were not using ASAN
+        run: |
+          nm target/client | grep -v '__asan_init'
+          nm target/server | grep -v '__asan_init'
 
   valgrind:
     name: Valgrind

--- a/.github/workflows/libssl.yaml
+++ b/.github/workflows/libssl.yaml
@@ -39,8 +39,8 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
 
-      - run: make PROFILE=release test
-      - run: make PROFILE=release integration
+      - run: make PROFILE=debug test
+      - run: make PROFILE=debug integration
 
   valgrind:
     name: Valgrind
@@ -55,7 +55,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y valgrind
       - name: Install build dependencies
         run: sudo apt-get update && sudo apt-get install -y openssl libssl3 libssl-dev lld
-      - run: VALGRIND="valgrind -q" make test integration
+      - run: VALGRIND="valgrind -q" make PROFILE=release test integration
 
   docs:
     name: Check for documentation errors

--- a/rustls-libssl/Makefile
+++ b/rustls-libssl/Makefile
@@ -4,9 +4,11 @@ CARGOFLAGS += --locked
 CFLAGS := -Werror -Wall -Wextra -Wpedantic -g $(shell pkg-config --cflags openssl)
 PROFILE := debug
 
+ifeq ($(PROFILE), debug)
 ifeq ($(CC), clang)
 	CFLAGS += -fsanitize=address -fsanitize=undefined
 	LDFLAGS += -fsanitize=address
+endif
 endif
 
 ifeq ($(PROFILE), release)

--- a/rustls-libssl/Makefile
+++ b/rustls-libssl/Makefile
@@ -5,10 +5,8 @@ CFLAGS := -Werror -Wall -Wextra -Wpedantic -g $(shell pkg-config --cflags openss
 PROFILE := debug
 
 ifeq ($(PROFILE), debug)
-ifeq ($(CC), clang)
 	CFLAGS += -fsanitize=address -fsanitize=undefined
-	LDFLAGS += -fsanitize=address
-endif
+	LDFLAGS += -fsanitize=address -fsanitize=undefined
 endif
 
 ifeq ($(PROFILE), release)

--- a/rustls-libssl/simpleserv.sh
+++ b/rustls-libssl/simpleserv.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-openssl s_server \
-  -cert test-ca/rsa/end.cert \
-  -cert_chain test-ca/rsa/inter.cert \
-  -key test-ca/rsa/end.key \
-  -alpn "hello,world" \
-  -accept localhost:4443 \
-  -rev

--- a/rustls-libssl/simpleserv.sh
+++ b/rustls-libssl/simpleserv.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+openssl s_server \
+  -cert test-ca/rsa/end.cert \
+  -cert_chain test-ca/rsa/inter.cert \
+  -key test-ca/rsa/end.key \
+  -alpn "hello,world" \
+  -accept localhost:4443 \
+  -rev


### PR DESCRIPTION
See https://github.com/rustls/rustls-ffi/issues/423 & https://github.com/rustls/rustls-ffi/pull/425 

I think the main bit of use for this repo is that it enables ASAN for GCC builds. Since we're not using `clang` in CI this should be a helpful test improvement.