### PR TITLE
Server-side resumption support

### DIFF
--- a/rustls-libssl/MATRIX.md
+++ b/rustls-libssl/MATRIX.md
@@ -461,7 +461,7 @@
 | `SSL_set_security_callback`  |  |  |  |
 | `SSL_set_security_level`  |  |  |  |
 | `SSL_set_session`  | :white_check_mark: | :white_check_mark: | :exclamation: [^stub] |
-| `SSL_set_session_id_context`  |  |  | :exclamation: [^stub] |
+| `SSL_set_session_id_context`  |  |  |  |
 | `SSL_set_session_secret_cb`  |  |  |  |
 | `SSL_set_session_ticket_ext`  |  |  |  |
 | `SSL_set_session_ticket_ext_cb`  |  |  |  |

--- a/rustls-libssl/MATRIX.md
+++ b/rustls-libssl/MATRIX.md
@@ -104,7 +104,7 @@
 | `SSL_CTX_get_security_callback`  |  |  |  |
 | `SSL_CTX_get_security_level`  |  |  |  |
 | `SSL_CTX_get_ssl_method`  |  |  |  |
-| `SSL_CTX_get_timeout`  |  | :white_check_mark: | :exclamation: [^stub] |
+| `SSL_CTX_get_timeout`  |  | :white_check_mark: | :white_check_mark: |
 | `SSL_CTX_get_verify_callback`  |  | :white_check_mark: | :white_check_mark: |
 | `SSL_CTX_get_verify_depth`  |  | :white_check_mark: | :white_check_mark: |
 | `SSL_CTX_get_verify_mode`  |  | :white_check_mark: | :white_check_mark: |
@@ -191,7 +191,7 @@
 | `SSL_CTX_set_ssl_version` [^deprecatedin_3_0] |  |  |  |
 | `SSL_CTX_set_stateless_cookie_generate_cb`  |  |  |  |
 | `SSL_CTX_set_stateless_cookie_verify_cb`  |  |  |  |
-| `SSL_CTX_set_timeout`  |  | :white_check_mark: | :exclamation: [^stub] |
+| `SSL_CTX_set_timeout`  |  | :white_check_mark: | :white_check_mark: |
 | `SSL_CTX_set_tlsext_max_fragment_length`  |  |  |  |
 | `SSL_CTX_set_tlsext_ticket_key_evp_cb`  |  |  |  |
 | `SSL_CTX_set_tlsext_use_srtp` [^srtp] |  |  |  |

--- a/rustls-libssl/MATRIX.md
+++ b/rustls-libssl/MATRIX.md
@@ -119,9 +119,9 @@
 | `SSL_CTX_sess_get_get_cb`  |  |  |  |
 | `SSL_CTX_sess_get_new_cb`  |  |  |  |
 | `SSL_CTX_sess_get_remove_cb`  |  |  |  |
-| `SSL_CTX_sess_set_get_cb`  |  | :white_check_mark: | :exclamation: [^stub] |
-| `SSL_CTX_sess_set_new_cb`  | :white_check_mark: | :white_check_mark: | :exclamation: [^stub] |
-| `SSL_CTX_sess_set_remove_cb`  |  | :white_check_mark: | :exclamation: [^stub] |
+| `SSL_CTX_sess_set_get_cb`  |  | :white_check_mark: | :white_check_mark: |
+| `SSL_CTX_sess_set_new_cb`  | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| `SSL_CTX_sess_set_remove_cb`  |  | :white_check_mark: | :white_check_mark: |
 | `SSL_CTX_sessions`  |  |  |  |
 | `SSL_CTX_set0_CA_list`  |  |  |  |
 | `SSL_CTX_set0_ctlog_store` [^ct] |  |  |  |

--- a/rustls-libssl/MATRIX.md
+++ b/rustls-libssl/MATRIX.md
@@ -216,7 +216,7 @@
 | `SSL_CTX_use_serverinfo_ex`  |  |  |  |
 | `SSL_CTX_use_serverinfo_file`  |  |  |  |
 | `SSL_SESSION_dup`  |  |  |  |
-| `SSL_SESSION_free`  | :white_check_mark: | :white_check_mark: | :exclamation: [^stub] |
+| `SSL_SESSION_free`  | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | `SSL_SESSION_get0_alpn_selected`  |  |  |  |
 | `SSL_SESSION_get0_cipher`  |  |  |  |
 | `SSL_SESSION_get0_hostname`  |  |  |  |
@@ -226,7 +226,7 @@
 | `SSL_SESSION_get0_ticket_appdata`  |  |  |  |
 | `SSL_SESSION_get_compress_id`  |  |  |  |
 | `SSL_SESSION_get_ex_data`  |  |  |  |
-| `SSL_SESSION_get_id`  |  | :white_check_mark: | :exclamation: [^stub] |
+| `SSL_SESSION_get_id`  |  | :white_check_mark: | :white_check_mark: |
 | `SSL_SESSION_get_master_key`  |  |  |  |
 | `SSL_SESSION_get_max_early_data`  |  |  |  |
 | `SSL_SESSION_get_max_fragment_length`  |  |  |  |
@@ -252,7 +252,7 @@
 | `SSL_SESSION_set_protocol_version`  |  |  |  |
 | `SSL_SESSION_set_time`  |  |  |  |
 | `SSL_SESSION_set_timeout`  |  |  |  |
-| `SSL_SESSION_up_ref`  |  | :white_check_mark: | :exclamation: [^stub] |
+| `SSL_SESSION_up_ref`  |  | :white_check_mark: | :white_check_mark: |
 | `SSL_SRP_CTX_free` [^deprecatedin_3_0] [^srp] |  |  |  |
 | `SSL_SRP_CTX_init` [^deprecatedin_3_0] [^srp] |  |  |  |
 | `SSL_accept`  |  |  | :white_check_mark: |
@@ -519,8 +519,8 @@
 | `TLSv1_client_method` [^deprecatedin_1_1_0] [^tls1_method] |  |  |  |
 | `TLSv1_method` [^deprecatedin_1_1_0] [^tls1_method] |  |  |  |
 | `TLSv1_server_method` [^deprecatedin_1_1_0] [^tls1_method] |  |  |  |
-| `d2i_SSL_SESSION`  |  | :white_check_mark: | :exclamation: [^stub] |
-| `i2d_SSL_SESSION`  |  | :white_check_mark: | :exclamation: [^stub] |
+| `d2i_SSL_SESSION`  |  | :white_check_mark: | :white_check_mark: |
+| `i2d_SSL_SESSION`  |  | :white_check_mark: | :white_check_mark: |
 
 [^stub]: symbol exists, but just returns an error.
 [^deprecatedin_1_1_0]: deprecated in openssl 1.1.0

--- a/rustls-libssl/MATRIX.md
+++ b/rustls-libssl/MATRIX.md
@@ -316,7 +316,7 @@
 | `SSL_get0_security_ex_data`  |  |  |  |
 | `SSL_get0_verified_chain`  |  |  | :white_check_mark: |
 | `SSL_get1_peer_certificate`  | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| `SSL_get1_session`  |  | :white_check_mark: | :exclamation: [^stub] |
+| `SSL_get1_session`  |  | :white_check_mark: | :white_check_mark: |
 | `SSL_get1_supported_ciphers`  |  |  |  |
 | `SSL_get_SSL_CTX`  |  |  |  |
 | `SSL_get_all_async_fds`  |  |  |  |
@@ -364,7 +364,7 @@
 | `SSL_get_server_random`  |  |  |  |
 | `SSL_get_servername`  |  | :white_check_mark: | :white_check_mark: |
 | `SSL_get_servername_type`  |  |  | :white_check_mark: |
-| `SSL_get_session`  |  | :white_check_mark: | :exclamation: [^stub] |
+| `SSL_get_session`  |  | :white_check_mark: | :white_check_mark: |
 | `SSL_get_shared_ciphers`  |  |  |  |
 | `SSL_get_shared_sigalgs`  |  |  |  |
 | `SSL_get_shutdown`  | :white_check_mark: | :white_check_mark: | :white_check_mark: |

--- a/rustls-libssl/build.rs
+++ b/rustls-libssl/build.rs
@@ -174,7 +174,6 @@ const ENTRYPOINTS: &[&str] = &[
     "SSL_set_post_handshake_auth",
     "SSL_set_quiet_shutdown",
     "SSL_set_session",
-    "SSL_set_session_id_context",
     "SSL_set_shutdown",
     "SSL_set_SSL_CTX",
     "SSL_set_verify",

--- a/rustls-libssl/src/cache.rs
+++ b/rustls-libssl/src/cache.rs
@@ -1,4 +1,103 @@
+use std::collections::BTreeSet;
+use std::sync::{Arc, Mutex};
 use std::time::SystemTime;
+
+use crate::SslSession;
+
+/// A container for session caches that can live inside
+/// an `SSL_CTX` but outlive a rustls `ServerConfig`/`ClientConfig`
+pub struct SessionCaches {
+    max_size: usize,
+
+    /// the underlying server store. This outlives any given connection.
+    server: Arc<ServerSessionStorage>,
+}
+
+impl SessionCaches {
+    pub fn with_size(max_size: usize) -> Self {
+        // a user who has one `SSL_CTX` for both clients and servers will end
+        // up with twice as many sessions as this, since rustls caches
+        // client and server sessions separately.
+        //
+        // the common case is to have those separate (it is, for example,
+        // impossible to configure certs/keys separately for client and
+        // servers in a given `SSL_CTX`) so this should be ok.
+        Self {
+            max_size,
+            server: Arc::new(ServerSessionStorage::new(max_size)),
+        }
+    }
+
+    pub fn set_mode(&mut self, mode: u32) -> u32 {
+        self.server.set_mode(mode)
+    }
+
+    pub fn size(&self) -> usize {
+        self.max_size
+    }
+
+    pub fn set_size(&mut self, size: usize) -> usize {
+        let old_size = self.max_size;
+        self.max_size = size;
+        self.server.set_size(size);
+        old_size
+    }
+}
+
+impl Default for SessionCaches {
+    fn default() -> Self {
+        // this is SSL_SESSION_CACHE_MAX_SIZE_DEFAULT
+        Self::with_size(1024 * 20)
+    }
+}
+
+#[derive(Debug)]
+pub struct ServerSessionStorage {
+    items: Mutex<BTreeSet<Arc<SslSession>>>,
+    parameters: Mutex<CacheParameters>,
+}
+
+impl ServerSessionStorage {
+    fn new(max_size: usize) -> Self {
+        Self {
+            items: Mutex::new(BTreeSet::new()),
+            parameters: Mutex::new(CacheParameters::new(max_size)),
+        }
+    }
+
+    fn set_mode(&self, mode: u32) -> u32 {
+        if let Ok(mut inner) = self.parameters.lock() {
+            let old = inner.mode;
+            inner.mode = mode;
+            old
+        } else {
+            0
+        }
+    }
+
+    fn set_size(&self, size: usize) {
+        if let Ok(mut inner) = self.parameters.lock() {
+            inner.max_size = size;
+        }
+    }
+}
+
+#[derive(Debug)]
+struct CacheParameters {
+    mode: u32,
+    max_size: usize,
+}
+
+impl CacheParameters {
+    fn new(max_size: usize) -> Self {
+        Self {
+            mode: CACHE_MODE_SERVER,
+            max_size,
+        }
+    }
+}
+
+const CACHE_MODE_SERVER: u32 = 0x02;
 
 #[derive(Debug, Clone, Copy)]
 pub struct ExpiryTime(pub u64);

--- a/rustls-libssl/src/cache.rs
+++ b/rustls-libssl/src/cache.rs
@@ -85,6 +85,10 @@ impl SessionCaches {
     pub fn set_get_callback(&mut self, callback: SSL_CTX_sess_get_cb) {
         self.server.set_get_callback(callback);
     }
+
+    pub fn set_context(&mut self, context: &[u8]) {
+        self.server.set_context(context);
+    }
 }
 
 impl Default for SessionCaches {
@@ -165,12 +169,19 @@ impl ServerSessionStorage {
             inner.callbacks.ssl_ctx = ssl_ctx;
         }
     }
+
+    fn set_context(&self, context: &[u8]) {
+        if let Ok(mut inner) = self.parameters.lock() {
+            context.clone_into(&mut inner.context);
+        }
+    }
 }
 
 #[derive(Debug)]
 struct CacheParameters {
     callbacks: CacheCallbacks,
     mode: u32,
+    context: Vec<u8>,
     max_size: usize,
     time_out: u64,
 }
@@ -180,6 +191,7 @@ impl CacheParameters {
         Self {
             callbacks: CacheCallbacks::default(),
             mode: CACHE_MODE_SERVER,
+            context: vec![],
             max_size,
             // See <https://www.openssl.org/docs/manmaster/man3/SSL_get_default_timeout.html>
             time_out: 300,

--- a/rustls-libssl/src/cache.rs
+++ b/rustls-libssl/src/cache.rs
@@ -47,6 +47,14 @@ impl SessionCaches {
         self.server.set_mode(mode)
     }
 
+    pub fn get_timeout(&self) -> u64 {
+        self.server.get_timeout()
+    }
+
+    pub fn set_timeout(&mut self, timeout: u64) -> u64 {
+        self.server.set_timeout(timeout)
+    }
+
     pub fn size(&self) -> usize {
         self.max_size
     }
@@ -92,6 +100,24 @@ impl ServerSessionStorage {
         }
     }
 
+    fn get_timeout(&self) -> u64 {
+        self.parameters
+            .lock()
+            .map(|inner| inner.time_out)
+            .unwrap_or_default()
+    }
+
+    fn set_timeout(&self, time_out: u64) -> u64 {
+        self.parameters
+            .lock()
+            .map(|mut inner| {
+                let old = inner.time_out;
+                inner.time_out = time_out;
+                old
+            })
+            .unwrap_or_default()
+    }
+
     fn set_size(&self, size: usize) {
         if let Ok(mut inner) = self.parameters.lock() {
             inner.max_size = size;
@@ -103,6 +129,7 @@ impl ServerSessionStorage {
 struct CacheParameters {
     mode: u32,
     max_size: usize,
+    time_out: u64,
 }
 
 impl CacheParameters {
@@ -110,6 +137,8 @@ impl CacheParameters {
         Self {
             mode: CACHE_MODE_SERVER,
             max_size,
+            // See <https://www.openssl.org/docs/manmaster/man3/SSL_get_default_timeout.html>
+            time_out: 300,
         }
     }
 }

--- a/rustls-libssl/src/cache.rs
+++ b/rustls-libssl/src/cache.rs
@@ -302,6 +302,24 @@ impl SingleServerCache {
             *old = Some(sess);
         }
     }
+
+    pub fn get_most_recent_session(&self) -> Option<Arc<SslSession>> {
+        self.most_recent_session
+            .lock()
+            .ok()
+            .and_then(|inner| inner.clone())
+    }
+
+    pub fn borrow_most_recent_session(&self) -> *mut SSL_SESSION {
+        if let Ok(inner) = self.most_recent_session.lock() {
+            inner
+                .as_ref()
+                .map(|sess| Arc::as_ptr(sess) as *mut SSL_SESSION)
+                .unwrap_or_else(ptr::null_mut)
+        } else {
+            ptr::null_mut()
+        }
+    }
 }
 
 impl StoresServerSessions for SingleServerCache {

--- a/rustls-libssl/src/cache.rs
+++ b/rustls-libssl/src/cache.rs
@@ -1,0 +1,28 @@
+use std::time::SystemTime;
+
+#[derive(Debug, Clone, Copy)]
+pub struct ExpiryTime(pub u64);
+
+impl ExpiryTime {
+    fn calculate(now: TimeBase, life_time_secs: u64) -> ExpiryTime {
+        ExpiryTime(now.0.saturating_add(life_time_secs))
+    }
+
+    pub fn in_past(&self, time: TimeBase) -> bool {
+        self.0 < time.0
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct TimeBase(u64);
+
+impl TimeBase {
+    pub fn now() -> Self {
+        Self(
+            SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .map(|n| n.as_secs())
+                .unwrap_or_default(),
+        )
+    }
+}

--- a/rustls-libssl/src/entry.rs
+++ b/rustls-libssl/src/entry.rs
@@ -639,11 +639,14 @@ entry! {
 
 entry! {
     pub fn _SSL_CTX_set_session_id_context(
-        _ctx: *mut SSL_CTX,
-        _sid_ctx: *const c_uchar,
-        _sid_ctx_len: c_uint,
+        ctx: *mut SSL_CTX,
+        sid_ctx: *const c_uchar,
+        sid_ctx_len: c_uint,
     ) -> c_int {
-        log::warn!("SSL_CTX_set_session_id_context not yet implemented");
+        let sid_ctx = try_slice!(sid_ctx, sid_ctx_len);
+        try_clone_arc!(ctx)
+            .get_mut()
+            .set_session_id_context(sid_ctx);
         C_INT_SUCCESS
     }
 }
@@ -1685,14 +1688,6 @@ entry_stub! {
 
 entry_stub! {
     pub fn _SSL_CTX_remove_session(_ssl: *const SSL, _session: *mut SSL_SESSION) -> c_int;
-}
-
-entry_stub! {
-    pub fn _SSL_set_session_id_context(
-        _ssl: *mut SSL,
-        _sid_ctx: *const c_uchar,
-        _sid_ctx_len: c_uint,
-    ) -> c_int;
 }
 
 entry_stub! {

--- a/rustls-libssl/src/entry.rs
+++ b/rustls-libssl/src/entry.rs
@@ -652,6 +652,48 @@ entry! {
 }
 
 entry! {
+    pub fn _SSL_CTX_sess_set_new_cb(ctx: *mut SSL_CTX, new_session_cb: SSL_CTX_new_session_cb) {
+        try_clone_arc!(ctx)
+            .get_mut()
+            .set_session_new_cb(new_session_cb)
+    }
+}
+
+pub type SSL_CTX_new_session_cb =
+    Option<unsafe extern "C" fn(_ssl: *mut SSL, _sess: *mut SSL_SESSION) -> c_int>;
+
+entry! {
+    pub fn _SSL_CTX_sess_set_get_cb(ctx: *mut SSL_CTX, get_session_cb: SSL_CTX_sess_get_cb) {
+        try_clone_arc!(ctx)
+            .get_mut()
+            .set_session_get_cb(get_session_cb)
+    }
+}
+
+pub type SSL_CTX_sess_get_cb = Option<
+    unsafe extern "C" fn(
+        ssl: *mut SSL,
+        data: *const c_uchar,
+        len: c_int,
+        copy: *mut c_int,
+    ) -> *mut SSL_SESSION,
+>;
+
+entry! {
+    pub fn _SSL_CTX_sess_set_remove_cb(
+        ctx: *mut SSL_CTX,
+        remove_session_cb: SSL_CTX_sess_remove_cb,
+    ) {
+        try_clone_arc!(ctx)
+            .get_mut()
+            .set_session_remove_cb(remove_session_cb)
+    }
+}
+
+pub type SSL_CTX_sess_remove_cb =
+    Option<unsafe extern "C" fn(ctx: *mut SSL_CTX, sess: *mut SSL_SESSION)>;
+
+entry! {
     pub fn _SSL_CTX_get_timeout(ctx: *const SSL_CTX) -> c_long {
         try_clone_arc!(ctx).get().get_session_timeout() as c_long
     }
@@ -1649,29 +1691,6 @@ entry_stub! {
 }
 
 entry_stub! {
-    pub fn _SSL_CTX_sess_set_get_cb(_ctx: *mut SSL_CTX, _get_session_cb: SSL_CTX_sess_get_cb);
-}
-
-pub type SSL_CTX_sess_get_cb = Option<
-    unsafe extern "C" fn(
-        ssl: *mut SSL,
-        data: *const c_uchar,
-        len: c_int,
-        copy: *mut c_int,
-    ) -> *mut SSL_SESSION,
->;
-
-entry_stub! {
-    pub fn _SSL_CTX_sess_set_remove_cb(
-        _ctx: *mut SSL_CTX,
-        _remove_session_cb: SSL_CTX_sess_remove_cb,
-    );
-}
-
-pub type SSL_CTX_sess_remove_cb =
-    Option<unsafe extern "C" fn(ctx: *mut SSL_CTX, sess: *mut SSL_SESSION)>;
-
-entry_stub! {
     pub fn _SSL_set_session_id_context(
         _ssl: *mut SSL,
         _sid_ctx: *const c_uchar,
@@ -1689,13 +1708,6 @@ pub type SSL_CTX_keylog_cb_func =
 entry_stub! {
     pub fn _SSL_CTX_add_client_CA(_ctx: *mut SSL_CTX, _x: *mut X509) -> c_int;
 }
-
-entry_stub! {
-    pub fn _SSL_CTX_sess_set_new_cb(_ctx: *mut SSL_CTX, _new_session_cb: SSL_CTX_new_session_cb);
-}
-
-pub type SSL_CTX_new_session_cb =
-    Option<unsafe extern "C" fn(_ssl: *mut SSL, _sess: *mut SSL_SESSION) -> c_int>;
 
 entry_stub! {
     pub fn _SSL_CTX_set_ciphersuites(_ctx: *mut SSL_CTX, _s: *const c_char) -> c_int;

--- a/rustls-libssl/src/entry.rs
+++ b/rustls-libssl/src/entry.rs
@@ -651,6 +651,19 @@ entry! {
     }
 }
 
+entry! {
+    pub fn _SSL_CTX_get_timeout(ctx: *const SSL_CTX) -> c_long {
+        try_clone_arc!(ctx).get().get_session_timeout() as c_long
+    }
+}
+
+entry! {
+    pub fn _SSL_CTX_set_timeout(ctx: *mut SSL_CTX, t: c_long) -> c_long {
+        let t = if t < 0 { 0 } else { t as u64 };
+        try_clone_arc!(ctx).get_mut().set_session_timeout(t) as c_long
+    }
+}
+
 impl Castable for SSL_CTX {
     type Ownership = OwnershipArc;
     type RustType = NotThreadSafe<SSL_CTX>;
@@ -1717,14 +1730,6 @@ entry_stub! {
         _num: usize,
         _readbytes: *mut usize,
     ) -> c_int;
-}
-
-entry_stub! {
-    pub fn _SSL_CTX_get_timeout(_ctx: *const SSL_CTX) -> c_long;
-}
-
-entry_stub! {
-    pub fn _SSL_CTX_set_timeout(_ctx: *mut SSL_CTX, _t: c_long) -> c_long;
 }
 
 entry_stub! {

--- a/rustls-libssl/src/entry.rs
+++ b/rustls-libssl/src/entry.rs
@@ -228,6 +228,19 @@ entry! {
                 ctx.get_mut().set_servername_callback_context(parg);
                 C_INT_SUCCESS as c_long
             }
+            Ok(SslCtrl::SetSessCacheSize) => {
+                if larg < 0 {
+                    return 0;
+                }
+                ctx.get_mut().set_session_cache_size(larg as usize) as c_long
+            }
+            Ok(SslCtrl::GetSessCacheSize) => ctx.get().get_session_cache_size() as c_long,
+            Ok(SslCtrl::SetSessCacheMode) => {
+                if larg < 0 {
+                    return 0;
+                }
+                ctx.get_mut().set_session_cache_mode(larg as u32) as c_long
+            }
             Err(()) => {
                 log::warn!("unimplemented _SSL_CTX_ctrl(..., {cmd}, {larg}, ...)");
                 0
@@ -748,7 +761,11 @@ entry! {
                 C_INT_SUCCESS as i64
             }
             // not a defined operation in the OpenSSL API
-            Ok(SslCtrl::SetTlsExtServerNameCallback) | Ok(SslCtrl::SetTlsExtServerNameArg) => 0,
+            Ok(SslCtrl::SetTlsExtServerNameCallback)
+            | Ok(SslCtrl::SetTlsExtServerNameArg)
+            | Ok(SslCtrl::SetSessCacheSize)
+            | Ok(SslCtrl::GetSessCacheSize)
+            | Ok(SslCtrl::SetSessCacheMode) => 0,
             Err(()) => {
                 log::warn!("unimplemented _SSL_ctrl(..., {cmd}, {larg}, ...)");
                 0
@@ -1560,6 +1577,9 @@ num_enum! {
     enum SslCtrl {
         Mode = 33,
         SetMsgCallbackArg = 16,
+        SetSessCacheSize = 42,
+        GetSessCacheSize = 43,
+        SetSessCacheMode = 44,
         SetTlsExtServerNameCallback = 53,
         SetTlsExtServerNameArg = 54,
         SetTlsExtHostname = 55,

--- a/rustls-libssl/src/entry.rs
+++ b/rustls-libssl/src/entry.rs
@@ -21,9 +21,9 @@ use crate::error::{ffi_panic_boundary, Error, MysteriouslyOppositeReturnValue};
 use crate::evp_pkey::EvpPkey;
 use crate::ex_data::ExData;
 use crate::ffi::{
-    clone_arc, free_arc, str_from_cstring, to_arc_mut_ptr, try_clone_arc, try_from,
-    try_mut_slice_int, try_ref_from_ptr, try_slice, try_slice_int, try_str, Castable, OwnershipArc,
-    OwnershipRef,
+    clone_arc, free_arc, free_arc_into_inner, str_from_cstring, to_arc_mut_ptr, try_clone_arc,
+    try_from, try_mut_slice_int, try_ref_from_ptr, try_slice, try_slice_int, try_str, Castable,
+    OwnershipArc, OwnershipRef,
 };
 use crate::not_thread_safe::NotThreadSafe;
 use crate::x509::{load_certs, OwnedX509, OwnedX509Stack};
@@ -136,7 +136,9 @@ entry! {
 
 entry! {
     pub fn _SSL_CTX_free(ctx: *mut SSL_CTX) {
-        free_arc(ctx);
+        if let Some(inner) = free_arc_into_inner(ctx) {
+            inner.get_mut().flush_all_sessions();
+        }
     }
 }
 

--- a/rustls-libssl/src/ffi.rs
+++ b/rustls-libssl/src/ffi.rs
@@ -165,6 +165,21 @@ where
     drop(unsafe { Arc::from_raw(rs_typed) });
 }
 
+/// Similar to `free_arc`, but call `into_inner` on the Arc instead of just
+/// dropping it.
+///
+/// This returns `Some` if this was the last reference.
+pub(crate) fn free_arc_into_inner<C>(ptr: *const C) -> Option<C::RustType>
+where
+    C: Castable<Ownership = OwnershipArc>,
+{
+    if ptr.is_null() {
+        return None;
+    }
+    let rs_typed = cast_const_ptr(ptr);
+    Arc::into_inner(unsafe { Arc::from_raw(rs_typed) })
+}
+
 /// Convert a mutable pointer to a [`Castable`] to an optional `Box` over the underlying
 /// [`Castable::RustType`], and immediately let it fall out of scope to be freed.
 ///

--- a/rustls-libssl/src/lib.rs
+++ b/rustls-libssl/src/lib.rs
@@ -382,6 +382,7 @@ pub struct SslContext {
     method: &'static SslMethod,
     ex_data: ex_data::ExData,
     versions: EnabledVersions,
+    caches: cache::SessionCaches,
     raw_options: u64,
     verify_mode: VerifyMode,
     verify_depth: c_int,
@@ -403,6 +404,7 @@ impl SslContext {
             method,
             ex_data: ex_data::ExData::default(),
             versions: EnabledVersions::default(),
+            caches: cache::SessionCaches::default(),
             raw_options: 0,
             verify_mode: VerifyMode::default(),
             verify_depth: -1,
@@ -473,6 +475,18 @@ impl SslContext {
             .as_ref()
             .map(|v| u16::from(*v))
             .unwrap_or_default()
+    }
+
+    fn get_session_cache_size(&self) -> usize {
+        self.caches.size()
+    }
+
+    fn set_session_cache_size(&mut self, size: usize) -> usize {
+        self.caches.set_size(size)
+    }
+
+    fn set_session_cache_mode(&mut self, mode: u32) -> u32 {
+        self.caches.set_mode(mode)
     }
 
     fn set_max_early_data(&mut self, max: u32) {

--- a/rustls-libssl/src/lib.rs
+++ b/rustls-libssl/src/lib.rs
@@ -498,6 +498,10 @@ impl SslContext {
         self.caches.set_mode(mode)
     }
 
+    fn set_session_id_context(&mut self, context: &[u8]) {
+        self.caches.set_context(context);
+    }
+
     fn set_session_new_cb(&mut self, callback: entry::SSL_CTX_new_session_cb) {
         self.caches.set_new_callback(callback);
     }

--- a/rustls-libssl/src/lib.rs
+++ b/rustls-libssl/src/lib.rs
@@ -422,8 +422,16 @@ impl SslContext {
         }
     }
 
-    fn install_ex_data(&mut self, ex_data: ex_data::ExData) {
-        self.ex_data = ex_data;
+    fn complete_construction(
+        &mut self,
+        pointer_to_self: *mut entry::SSL_CTX,
+    ) -> Result<(), error::Error> {
+        self.caches.set_pointer_to_owning_ssl_ctx(pointer_to_self);
+
+        self.ex_data = ex_data::ExData::new_ssl_ctx(pointer_to_self)
+            .ok_or_else(|| error::Error::bad_data("ex_data construction failed"))?;
+
+        Ok(())
     }
 
     fn set_ex_data(&mut self, idx: c_int, data: *mut c_void) -> Result<(), error::Error> {

--- a/rustls-libssl/src/lib.rs
+++ b/rustls-libssl/src/lib.rs
@@ -490,6 +490,18 @@ impl SslContext {
         self.caches.set_mode(mode)
     }
 
+    fn set_session_new_cb(&mut self, callback: entry::SSL_CTX_new_session_cb) {
+        self.caches.set_new_callback(callback);
+    }
+
+    fn set_session_get_cb(&mut self, callback: entry::SSL_CTX_sess_get_cb) {
+        self.caches.set_get_callback(callback);
+    }
+
+    fn set_session_remove_cb(&mut self, callback: entry::SSL_CTX_sess_remove_cb) {
+        self.caches.set_remove_callback(callback);
+    }
+
     fn get_session_timeout(&self) -> u64 {
         self.caches.get_timeout()
     }

--- a/rustls-libssl/src/lib.rs
+++ b/rustls-libssl/src/lib.rs
@@ -1393,6 +1393,22 @@ impl Ssl {
             None => false,
         }
     }
+
+    fn get_current_session(&self) -> Option<Arc<SslSession>> {
+        match &self.conn {
+            ConnState::Server(_, _, cache) => cache.get_most_recent_session(),
+            // divergence: `SSL_get1_session` etc only work for server SSLs
+            _ => None,
+        }
+    }
+
+    fn borrow_current_session(&self) -> *mut entry::SSL_SESSION {
+        match &self.conn {
+            ConnState::Server(_, _, cache) => cache.borrow_most_recent_session(),
+            // divergence: `SSL_get_session` etc only work for server SSLs
+            _ => ptr::null_mut(),
+        }
+    }
 }
 
 /// Encode rustls's internal representation in the wire format.

--- a/rustls-libssl/src/lib.rs
+++ b/rustls-libssl/src/lib.rs
@@ -490,6 +490,14 @@ impl SslContext {
         self.caches.set_mode(mode)
     }
 
+    fn get_session_timeout(&self) -> u64 {
+        self.caches.get_timeout()
+    }
+
+    fn set_session_timeout(&mut self, timeout: u64) -> u64 {
+        self.caches.set_timeout(timeout)
+    }
+
     fn set_max_early_data(&mut self, max: u32) {
         self.max_early_data = max;
     }

--- a/rustls-libssl/src/lib.rs
+++ b/rustls-libssl/src/lib.rs
@@ -522,6 +522,10 @@ impl SslContext {
         self.caches.set_timeout(timeout)
     }
 
+    fn flush_all_sessions(&mut self) {
+        self.caches.flush_all();
+    }
+
     fn set_max_early_data(&mut self, max: u32) {
         self.max_early_data = max;
     }

--- a/rustls-libssl/tests/nginx.conf
+++ b/rustls-libssl/tests/nginx.conf
@@ -10,10 +10,11 @@ http {
     access_log access.log;
 
     server {
+        # no resumption (default)
         listen 8443 ssl;
-        server_name localhost;
         ssl_certificate ../../../test-ca/rsa/server.cert;
         ssl_certificate_key ../../../test-ca/rsa/server.key;
+        server_name localhost;
 
         location = / {
             return 200 "hello world\n";
@@ -42,6 +43,83 @@ http {
 
         location /ssl-client-auth {
             return 200 "s-dn:$ssl_client_s_dn\ni-dn:$ssl_client_i_dn\nserial:$ssl_client_serial\nfp:$ssl_client_fingerprint\nverify:$ssl_client_verify\nv-start:$ssl_client_v_start\nv-end:$ssl_client_v_end\nv-remain:$ssl_client_v_remain\ncert:\n$ssl_client_cert\n";
+        }
+    }
+
+    server {
+        # per-worker resumption
+        listen 8444 ssl;
+        ssl_session_cache builtin;
+        ssl_certificate ../../../test-ca/rsa/server.cert;
+        ssl_certificate_key ../../../test-ca/rsa/server.key;
+        server_name localhost;
+
+        location = / {
+            return 200 "hello world\n";
+        }
+
+        location /ssl-agreed {
+            return 200 "protocol:$ssl_protocol,cipher:$ssl_cipher\n";
+        }
+
+        location /ssl-server-name {
+            return 200 "server-name:$ssl_server_name\n";
+        }
+
+        location /ssl-was-reused {
+            return 200 "reused:$ssl_session_reused\n";
+        }
+    }
+
+    server {
+        # per-worker & per-server resumption
+        listen 8445 ssl;
+        ssl_session_cache builtin shared:port8445:1M;
+        ssl_certificate ../../../test-ca/rsa/server.cert;
+        ssl_certificate_key ../../../test-ca/rsa/server.key;
+        server_name localhost;
+
+
+        location = / {
+            return 200 "hello world\n";
+        }
+
+        location /ssl-agreed {
+            return 200 "protocol:$ssl_protocol,cipher:$ssl_cipher\n";
+        }
+
+        location /ssl-server-name {
+            return 200 "server-name:$ssl_server_name\n";
+        }
+
+        location /ssl-was-reused {
+            return 200 "reused:$ssl_session_reused\n";
+        }
+
+    }
+
+    server {
+        # per-server resumption
+        listen 8446 ssl;
+        ssl_session_cache shared:port8446:1M;
+        ssl_certificate ../../../test-ca/rsa/server.cert;
+        ssl_certificate_key ../../../test-ca/rsa/server.key;
+        server_name localhost;
+
+        location = / {
+            return 200 "hello world\n";
+        }
+
+        location /ssl-agreed {
+            return 200 "protocol:$ssl_protocol,cipher:$ssl_cipher\n";
+        }
+
+        location /ssl-server-name {
+            return 200 "server-name:$ssl_server_name\n";
+        }
+
+        location /ssl-was-reused {
+            return 200 "reused:$ssl_session_reused\n";
         }
     }
 }

--- a/rustls-libssl/tests/server.c
+++ b/rustls-libssl/tests/server.c
@@ -123,6 +123,10 @@ int main(int argc, char **argv) {
   SSL_CTX_set_tlsext_servername_arg(ctx, &sni_cookie);
   dump_openssl_error_stack();
 
+  TRACE(SSL_CTX_sess_set_cache_size(ctx, 10));
+  TRACE(SSL_CTX_sess_get_cache_size(ctx));
+  TRACE(SSL_CTX_set_session_cache_mode(ctx, SSL_SESS_CACHE_SERVER));
+
   X509 *server_cert = NULL;
   EVP_PKEY *server_key = NULL;
   TRACE(SSL_CTX_use_certificate_chain_file(ctx, certfile));


### PR DESCRIPTION
This PR has as a goal getting the tests in the final commit to pass. Those extend the existing nginx integration test to start 4 different servers with varying resumption options (none, per-worker, per-server, and per-worker+server together) and see that resumption works in a basic sense.

Some of the earlier commits put into place infrastructure that isn't fully used until the last one (for example, the fields on `SslSession`).