### PR TITLE
Starting support for curl 8.5.0

### DIFF
--- a/rustls-libssl/MATRIX.md
+++ b/rustls-libssl/MATRIX.md
@@ -347,7 +347,7 @@
 | `SSL_get_options`  |  | :white_check_mark: | :white_check_mark: |
 | `SSL_get_peer_cert_chain`  | :white_check_mark: |  | :white_check_mark: |
 | `SSL_get_peer_finished`  |  |  |  |
-| `SSL_get_peer_signature_type_nid`  |  |  |  |
+| `SSL_get_peer_signature_type_nid`  |  |  | :white_check_mark: |
 | `SSL_get_pending_cipher`  |  |  |  |
 | `SSL_get_privatekey`  | :white_check_mark: |  | :white_check_mark: |
 | `SSL_get_psk_identity` [^psk] |  |  |  |

--- a/rustls-libssl/MATRIX.md
+++ b/rustls-libssl/MATRIX.md
@@ -136,7 +136,7 @@
 | `SSL_CTX_set_async_callback_arg`  |  |  |  |
 | `SSL_CTX_set_block_padding`  |  |  |  |
 | `SSL_CTX_set_cert_cb`  |  | :white_check_mark: | :white_check_mark: |
-| `SSL_CTX_set_cert_store`  |  |  |  |
+| `SSL_CTX_set_cert_store`  |  |  | :white_check_mark: |
 | `SSL_CTX_set_cert_verify_callback`  |  |  |  |
 | `SSL_CTX_set_cipher_list`  | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | `SSL_CTX_set_ciphersuites`  | :white_check_mark: |  | :exclamation: [^stub] |

--- a/rustls-libssl/build.rs
+++ b/rustls-libssl/build.rs
@@ -143,6 +143,7 @@ const ENTRYPOINTS: &[&str] = &[
     "SSL_get_ex_data_X509_STORE_CTX_idx",
     "SSL_get_options",
     "SSL_get_peer_cert_chain",
+    "SSL_get_peer_signature_type_nid",
     "SSL_get_privatekey",
     "SSL_get_rbio",
     "SSL_get_servername",

--- a/rustls-libssl/build.rs
+++ b/rustls-libssl/build.rs
@@ -96,6 +96,7 @@ const ENTRYPOINTS: &[&str] = &[
     "SSL_CTX_set_alpn_protos",
     "SSL_CTX_set_alpn_select_cb",
     "SSL_CTX_set_cert_cb",
+    "SSL_CTX_set_cert_store",
     "SSL_CTX_set_cipher_list",
     "SSL_CTX_set_ciphersuites",
     "SSL_CTX_set_client_CA_list",

--- a/rustls-libssl/src/constants.rs
+++ b/rustls-libssl/src/constants.rs
@@ -1,6 +1,10 @@
 use core::ffi::{c_int, CStr};
+use openssl_sys::{
+    NID_X9_62_prime256v1, NID_rsaEncryption, NID_rsassaPss, NID_secp384r1, NID_secp521r1,
+    NID_ED25519, NID_ED448,
+};
 
-use rustls::AlertDescription;
+use rustls::{AlertDescription, SignatureScheme};
 
 pub fn alert_desc_to_long_string(value: c_int) -> &'static CStr {
     match AlertDescription::from(value as u8) {
@@ -81,5 +85,20 @@ pub fn alert_desc_to_short_string(value: c_int) -> &'static CStr {
         // AlertDescription::MissingExtension => c"missing extension",
         // AlertDescription::CertificateRequired => c"certificate required",
         _ => c"UK",
+    }
+}
+
+pub fn sig_scheme_to_nid(scheme: SignatureScheme) -> Option<c_int> {
+    use SignatureScheme::*;
+    match scheme {
+        RSA_PKCS1_SHA256 | RSA_PKCS1_SHA384 | RSA_PKCS1_SHA512 => Some(NID_rsaEncryption),
+        RSA_PSS_SHA256 | RSA_PSS_SHA384 | RSA_PSS_SHA512 => Some(NID_rsassaPss),
+        ECDSA_NISTP256_SHA256 => Some(NID_X9_62_prime256v1),
+        ECDSA_NISTP384_SHA384 => Some(NID_secp384r1),
+        ECDSA_NISTP521_SHA512 => Some(NID_secp521r1),
+        ED25519 => Some(NID_ED25519),
+        ED448 => Some(NID_ED448),
+        // Omitted: SHA1 legacy schemes.
+        _ => None,
     }
 }

--- a/rustls-libssl/src/entry.rs
+++ b/rustls-libssl/src/entry.rs
@@ -297,6 +297,12 @@ entry! {
     }
 }
 
+entry! {
+    pub fn _SSL_CTX_set_cert_store(ctx: *mut SSL_CTX, store: *mut X509_STORE) {
+        try_clone_arc!(ctx).get_mut().set_x509_store(store);
+    }
+}
+
 fn load_verify_files(
     ctx: &NotThreadSafe<SSL_CTX>,
     file_names: impl Iterator<Item = PathBuf>,

--- a/rustls-libssl/src/lib.rs
+++ b/rustls-libssl/src/lib.rs
@@ -21,6 +21,7 @@ use rustls::{
 };
 
 use not_thread_safe::NotThreadSafe;
+use x509::OwnedX509Store;
 
 mod bio;
 mod cache;
@@ -435,7 +436,7 @@ impl SslContext {
             verify_mode: VerifyMode::default(),
             verify_depth: -1,
             verify_roots: RootCertStore::empty(),
-            verify_x509_store: x509::OwnedX509Store::new(),
+            verify_x509_store: OwnedX509Store::default(),
             alpn: vec![],
             default_cert_file: None,
             default_cert_dir: None,
@@ -613,6 +614,13 @@ impl SslContext {
 
     fn get_x509_store(&self) -> *mut X509_STORE {
         self.verify_x509_store.pointer()
+    }
+
+    fn set_x509_store(&mut self, store: *mut X509_STORE) {
+        self.verify_x509_store = match store.is_null() {
+            true => OwnedX509Store::default(),
+            false => OwnedX509Store::new(store),
+        };
     }
 
     fn set_alpn_offer(&mut self, alpn: Vec<Vec<u8>>) {

--- a/rustls-libssl/src/lib.rs
+++ b/rustls-libssl/src/lib.rs
@@ -17,7 +17,7 @@ use rustls::pki_types::{CertificateDer, ServerName};
 use rustls::server::{Accepted, Acceptor};
 use rustls::{
     CipherSuite, ClientConfig, ClientConnection, Connection, HandshakeKind, ProtocolVersion,
-    RootCertStore, ServerConfig, SupportedProtocolVersion,
+    RootCertStore, ServerConfig, SignatureScheme, SupportedProtocolVersion,
 };
 
 use not_thread_safe::NotThreadSafe;
@@ -1342,6 +1342,14 @@ impl Ssl {
             ConnState::Client(_, verifier) => verifier.last_result(),
             ConnState::Server(_, verifier, _) => verifier.last_result(),
             _ => X509_V_ERR_UNSPECIFIED as i64,
+        }
+    }
+
+    fn get_last_verification_sig_scheme(&self) -> Option<SignatureScheme> {
+        match &self.conn {
+            ConnState::Client(_, verifier) => verifier.last_sig_scheme(),
+            ConnState::Server(_, verifier, _) => verifier.last_sig_scheme(),
+            _ => None,
         }
     }
 

--- a/rustls-libssl/src/x509.rs
+++ b/rustls-libssl/src/x509.rs
@@ -237,14 +237,21 @@ pub struct OwnedX509Store {
 }
 
 impl OwnedX509Store {
-    pub fn new() -> Self {
-        Self {
-            raw: unsafe { X509_STORE_new() },
-        }
+    /// Create a new one, from a (donated) existing ref.
+    pub fn new(store: *mut X509_STORE) -> Self {
+        Self { raw: store }
     }
 
     pub fn pointer(&self) -> *mut X509_STORE {
         self.raw
+    }
+}
+
+impl Default for OwnedX509Store {
+    fn default() -> Self {
+        Self {
+            raw: unsafe { X509_STORE_new() },
+        }
     }
 }
 

--- a/rustls-libssl/tests/client.c
+++ b/rustls-libssl/tests/client.c
@@ -126,6 +126,10 @@ int main(int argc, char **argv) {
   printf("numeric version: %d\n", SSL_version(ssl));
   printf("verify-result: %ld\n", SSL_get_verify_result(ssl));
   printf("cipher: %s\n", SSL_CIPHER_standard_name(SSL_get_current_cipher(ssl)));
+  int cipher_nid = 0;
+  TRACE(SSL_get_peer_signature_type_nid(ssl, &cipher_nid));
+  dump_openssl_error_stack();
+  printf("cipher NID: %d\n", cipher_nid);
 
   show_peer_certificate("server", ssl);
 

--- a/rustls-libssl/tests/server.c
+++ b/rustls-libssl/tests/server.c
@@ -202,6 +202,11 @@ int main(int argc, char **argv) {
   printf("numeric version: %d\n", SSL_version(ssl));
   printf("verify-result: %ld\n", SSL_get_verify_result(ssl));
   printf("cipher: %s\n", SSL_CIPHER_standard_name(SSL_get_current_cipher(ssl)));
+  int cipher_nid = 0;
+  TRACE(SSL_get_peer_signature_type_nid(ssl, &cipher_nid));
+  dump_openssl_error_stack();
+  printf("cipher NID: %d\n", cipher_nid);
+
   printf("SSL_get_servername: %s (%d)\n",
          SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name),
          SSL_get_servername_type(ssl));


### PR DESCRIPTION
My local build of curl 8.5.0 (the version I believe is shipped on Ubuntu 24.04) requires two additional `libssl` symbols:

* `SSL_get_peer_signature_type_nid` - This is implemented in this branch.
* `SSL_CTX_set_cert_store` - we had already implemented `SSL_CTX_get_cert_store`, making this fairly straight-forward to impl.

With the above, curl 8.5.0 now runs without missing symbol errors, but I'm seeing `UnknownIssuer` errors that make me suspect there's still work to do. I believe these will be fixed by resolving https://github.com/rustls/rustls-openssl-compat/issues/17

<details>
<summary>Error output so far:</summary>

```
$> LD_LIBRARY_PATH=./target/release/ ldd $(which curl) | grep libssl
	libssl.so.3 => ./target/release/libssl.so.3 (0x00007ffff7a00000)
	
$> LD_LIBRARY_PATH=./target/release/ curl --version
curl 8.5.0 (x86_64-pc-linux-gnu) libcurl/8.5.0 OpenSSL/3.0.13 zlib/1.3 brotli/1.1.0 zstd/1.5.5 libidn2/2.3.4 libssh2/1.11.0 nghttp2/1.57.0
Release-Date: 2023-12-06
Protocols: dict file ftp ftps gopher gophers http https imap imaps mqtt pop3 pop3s rtsp scp sftp smb smbs smtp smtps telnet tftp
Features: alt-svc AsynchDNS brotli GSS-API HSTS HTTP2 HTTPS-proxy IDN IPv6 Kerberos Largefile libz NTLM SPNEGO SSL threadsafe TLS-SRP UnixSockets zstd

$> LD_LIBRARY_PATH=./target/release/ curl https://example.com
[2024-05-02T19:03:58Z ERROR ssl::error] raising Error { lib: Ssl, reason: Unsupported, string: Some("_SSL_CTX_set_post_handshake_auth") }
[2024-05-02T19:03:58Z ERROR ssl::error] raising Error { lib: User, reason: OperationFailed, string: Some("invalid peer certificate: UnknownIssuer") }
[2024-05-02T19:03:58Z ERROR ssl::error] raising Error { lib: User, reason: OperationFailed, string: Some("invalid peer certificate: UnknownIssuer") }
[2024-05-02T19:03:58Z ERROR ssl::error] raising Error { lib: User, reason: OperationFailed, string: Some("invalid peer certificate: UnknownIssuer") }
[2024-05-02T19:03:58Z ERROR ssl::error] raising Error { lib: User, reason: OperationFailed, string: Some("invalid peer certificate: UnknownIssuer") }
[2024-05-02T19:03:58Z ERROR ssl::error] raising Error { lib: User, reason: OperationFailed, string: Some("invalid peer certificate: UnknownIssuer") }
[2024-05-02T19:03:58Z ERROR ssl::error] raising Error { lib: User, reason: OperationFailed, string: Some("invalid peer certificate: UnknownIssuer") }
curl: (35) OpenSSL/3.0.13: error:400C0107:lib(128)::operation fail
```
</details>