### PR TITLE
Matrix updates for curl/nginx versions used by ubuntu 24.04

### DIFF
--- a/rustls-libssl/MATRIX.md
+++ b/rustls-libssl/MATRIX.md
@@ -49,16 +49,16 @@
 | `SSL_COMP_get_name`  |  |  |  |
 | `SSL_COMP_set0_compression_methods`  |  |  |  |
 | `SSL_CONF_CTX_clear_flags`  |  |  |  |
-| `SSL_CONF_CTX_finish`  |  |  | :exclamation: [^stub] |
-| `SSL_CONF_CTX_free`  |  |  | :exclamation: [^stub] |
-| `SSL_CONF_CTX_new`  |  |  | :exclamation: [^stub] |
+| `SSL_CONF_CTX_finish`  |  | :white_check_mark: | :exclamation: [^stub] |
+| `SSL_CONF_CTX_free`  |  | :white_check_mark: | :exclamation: [^stub] |
+| `SSL_CONF_CTX_new`  |  | :white_check_mark: | :exclamation: [^stub] |
 | `SSL_CONF_CTX_set1_prefix`  |  |  |  |
-| `SSL_CONF_CTX_set_flags`  |  |  | :exclamation: [^stub] |
+| `SSL_CONF_CTX_set_flags`  |  | :white_check_mark: | :exclamation: [^stub] |
 | `SSL_CONF_CTX_set_ssl`  |  |  |  |
-| `SSL_CONF_CTX_set_ssl_ctx`  |  |  | :exclamation: [^stub] |
-| `SSL_CONF_cmd`  |  |  | :exclamation: [^stub] |
+| `SSL_CONF_CTX_set_ssl_ctx`  |  | :white_check_mark: | :exclamation: [^stub] |
+| `SSL_CONF_cmd`  |  | :white_check_mark: | :exclamation: [^stub] |
 | `SSL_CONF_cmd_argv`  |  |  |  |
-| `SSL_CONF_cmd_value_type`  |  |  | :exclamation: [^stub] |
+| `SSL_CONF_cmd_value_type`  |  | :white_check_mark: | :exclamation: [^stub] |
 | `SSL_CTX_SRP_CTX_free` [^deprecatedin_3_0] [^srp] |  |  |  |
 | `SSL_CTX_SRP_CTX_init` [^deprecatedin_3_0] [^srp] |  |  |  |
 | `SSL_CTX_add1_to_CA_list`  |  |  |  |
@@ -136,7 +136,7 @@
 | `SSL_CTX_set_async_callback_arg`  |  |  |  |
 | `SSL_CTX_set_block_padding`  |  |  |  |
 | `SSL_CTX_set_cert_cb`  |  | :white_check_mark: | :white_check_mark: |
-| `SSL_CTX_set_cert_store`  |  |  | :white_check_mark: |
+| `SSL_CTX_set_cert_store`  | :white_check_mark: |  | :white_check_mark: |
 | `SSL_CTX_set_cert_verify_callback`  |  |  |  |
 | `SSL_CTX_set_cipher_list`  | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | `SSL_CTX_set_ciphersuites`  | :white_check_mark: |  | :exclamation: [^stub] |
@@ -232,8 +232,8 @@
 | `SSL_SESSION_get_max_fragment_length`  |  |  |  |
 | `SSL_SESSION_get_protocol_version`  |  |  |  |
 | `SSL_SESSION_get_ticket_lifetime_hint`  |  |  |  |
-| `SSL_SESSION_get_time`  |  |  | :white_check_mark: |
-| `SSL_SESSION_get_timeout`  |  |  | :white_check_mark: |
+| `SSL_SESSION_get_time`  |  | :white_check_mark: | :white_check_mark: |
+| `SSL_SESSION_get_timeout`  |  | :white_check_mark: | :white_check_mark: |
 | `SSL_SESSION_has_ticket`  |  |  |  |
 | `SSL_SESSION_is_resumable`  |  |  |  |
 | `SSL_SESSION_new`  |  |  |  |
@@ -243,15 +243,15 @@
 | `SSL_SESSION_set1_alpn_selected`  |  |  |  |
 | `SSL_SESSION_set1_hostname`  |  |  |  |
 | `SSL_SESSION_set1_id`  |  |  |  |
-| `SSL_SESSION_set1_id_context`  |  |  | :white_check_mark: |
+| `SSL_SESSION_set1_id_context`  |  | :white_check_mark: | :white_check_mark: |
 | `SSL_SESSION_set1_master_key`  |  |  |  |
 | `SSL_SESSION_set1_ticket_appdata`  |  |  |  |
 | `SSL_SESSION_set_cipher`  |  |  |  |
 | `SSL_SESSION_set_ex_data`  |  |  |  |
 | `SSL_SESSION_set_max_early_data`  |  |  |  |
 | `SSL_SESSION_set_protocol_version`  |  |  |  |
-| `SSL_SESSION_set_time`  |  |  | :white_check_mark: |
-| `SSL_SESSION_set_timeout`  |  |  | :white_check_mark: |
+| `SSL_SESSION_set_time`  |  | :white_check_mark: | :white_check_mark: |
+| `SSL_SESSION_set_timeout`  |  | :white_check_mark: | :white_check_mark: |
 | `SSL_SESSION_up_ref`  |  | :white_check_mark: | :white_check_mark: |
 | `SSL_SRP_CTX_free` [^deprecatedin_3_0] [^srp] |  |  |  |
 | `SSL_SRP_CTX_init` [^deprecatedin_3_0] [^srp] |  |  |  |
@@ -314,11 +314,11 @@
 | `SSL_get0_peer_scts` [^ct] |  |  |  |
 | `SSL_get0_peername`  |  |  |  |
 | `SSL_get0_security_ex_data`  |  |  |  |
-| `SSL_get0_verified_chain`  |  |  | :white_check_mark: |
+| `SSL_get0_verified_chain`  | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | `SSL_get1_peer_certificate`  | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | `SSL_get1_session`  |  | :white_check_mark: | :white_check_mark: |
 | `SSL_get1_supported_ciphers`  |  |  |  |
-| `SSL_get_SSL_CTX`  |  |  | :white_check_mark: |
+| `SSL_get_SSL_CTX`  |  | :white_check_mark: | :white_check_mark: |
 | `SSL_get_all_async_fds`  |  |  |  |
 | `SSL_get_async_status`  |  |  |  |
 | `SSL_get_certificate`  | :white_check_mark: | :white_check_mark: | :white_check_mark: |
@@ -345,9 +345,9 @@
 | `SSL_get_max_early_data`  |  |  |  |
 | `SSL_get_num_tickets`  |  |  |  |
 | `SSL_get_options`  |  | :white_check_mark: | :white_check_mark: |
-| `SSL_get_peer_cert_chain`  | :white_check_mark: |  | :white_check_mark: |
+| `SSL_get_peer_cert_chain`  | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | `SSL_get_peer_finished`  |  |  |  |
-| `SSL_get_peer_signature_type_nid`  |  |  | :white_check_mark: |
+| `SSL_get_peer_signature_type_nid`  | :white_check_mark: |  | :white_check_mark: |
 | `SSL_get_pending_cipher`  |  |  |  |
 | `SSL_get_privatekey`  | :white_check_mark: |  | :white_check_mark: |
 | `SSL_get_psk_identity` [^psk] |  |  |  |
@@ -409,13 +409,13 @@
 | `SSL_rstate_string`  |  |  |  |
 | `SSL_rstate_string_long`  |  |  |  |
 | `SSL_select_next_proto`  |  | :white_check_mark: | :white_check_mark: |
-| `SSL_sendfile`  |  |  | :exclamation: [^stub] |
+| `SSL_sendfile`  |  | :white_check_mark: | :exclamation: [^stub] |
 | `SSL_session_reused`  |  | :white_check_mark: | :white_check_mark: |
 | `SSL_set0_CA_list`  |  |  |  |
-| `SSL_set0_rbio`  |  |  | :white_check_mark: |
+| `SSL_set0_rbio`  | :white_check_mark: |  | :white_check_mark: |
 | `SSL_set0_security_ex_data`  |  |  |  |
 | `SSL_set0_tmp_dh_pkey`  |  |  |  |
-| `SSL_set0_wbio`  |  |  | :white_check_mark: |
+| `SSL_set0_wbio`  | :white_check_mark: |  | :white_check_mark: |
 | `SSL_set1_host`  |  |  | :white_check_mark: |
 | `SSL_set1_param`  |  |  |  |
 | `SSL_set_SSL_CTX`  |  | :white_check_mark: | :white_check_mark: |
@@ -498,7 +498,7 @@
 | `SSL_use_certificate_file`  |  |  |  |
 | `SSL_use_psk_identity_hint` [^psk] |  |  |  |
 | `SSL_verify_client_post_handshake`  |  |  |  |
-| `SSL_version`  |  |  | :white_check_mark: |
+| `SSL_version`  |  | :white_check_mark: | :white_check_mark: |
 | `SSL_waiting_for_async`  |  |  |  |
 | `SSL_want`  |  |  | :white_check_mark: |
 | `SSL_write`  | :white_check_mark: | :white_check_mark: | :white_check_mark: |

--- a/rustls-libssl/admin/matrix.py
+++ b/rustls-libssl/admin/matrix.py
@@ -55,7 +55,7 @@ def read_impls():
 
 impls = read_impls()
 
-# from ubuntu curl 7.81.0-1ubuntu1.15
+# Combined requirements of curl 7.81.0-1ubuntu1.15, and curl 8.5.0
 # extracted by running with LD_DEBUG=all
 CURL = set("""
 BIO_f_ssl
@@ -74,6 +74,7 @@ SSL_CTX_load_verify_file
 SSL_CTX_new
 SSL_CTX_sess_set_new_cb
 SSL_CTX_set_alpn_protos
+SSL_CTX_set_cert_store
 SSL_CTX_set_cipher_list
 SSL_CTX_set_ciphersuites
 SSL_CTX_set_default_passwd_cb
@@ -86,19 +87,23 @@ SSL_CTX_set_post_handshake_auth
 SSL_CTX_set_srp_password
 SSL_CTX_set_srp_username
 SSL_CTX_set_verify
+SSL_CTX_use_certificate
 SSL_CTX_use_certificate_chain_file
 SSL_CTX_use_certificate_file
 SSL_CTX_use_certificate
 SSL_CTX_use_PrivateKey_file
 SSL_CTX_use_PrivateKey
+SSL_CTX_use_PrivateKey_file
 SSL_free
 SSL_get0_alpn_selected
+SSL_get0_verified_chain
 SSL_get1_peer_certificate
 SSL_get_certificate
 SSL_get_current_cipher
 SSL_get_error
 SSL_get_ex_data
 SSL_get_peer_cert_chain
+SSL_get_peer_signature_type_nid
 SSL_get_privatekey
 SSL_get_shutdown
 SSL_get_verify_result
@@ -108,6 +113,8 @@ SSL_pending
 SSL_read
 SSL_SESSION_free
 SSL_set_bio
+SSL_set0_rbio
+SSL_set0_wbio
 SSL_set_connect_state
 SSL_set_ex_data
 SSL_set_fd

--- a/rustls-libssl/admin/matrix.py
+++ b/rustls-libssl/admin/matrix.py
@@ -124,7 +124,7 @@ SSL_write
 TLS_client_method
 """.split())
 
-# from ubuntu nginx 1.18.0-6ubuntu14.4
+# Combined requirements of nginx 1.18.0-6ubuntu14.4, and nginx 1.24.0
 # extracted by running with LD_DEBUG=all
 NGINX = set("""
 d2i_SSL_SESSION
@@ -134,6 +134,13 @@ SSL_CIPHER_description
 SSL_CIPHER_find
 SSL_CIPHER_get_name
 SSL_clear_options
+SSL_CONF_cmd
+SSL_CONF_cmd_value_type
+SSL_CONF_CTX_finish
+SSL_CONF_CTX_free
+SSL_CONF_CTX_new
+SSL_CONF_CTX_set_flags
+SSL_CONF_CTX_set_ssl_ctx
 SSL_ctrl
 SSL_CTX_callback_ctrl
 SSL_CTX_clear_options
@@ -168,12 +175,14 @@ SSL_CTX_set_session_id_context
 SSL_CTX_set_timeout
 SSL_CTX_set_verify_depth
 SSL_CTX_set_verify
+SSL_CTX_set_verify_depth
 SSL_CTX_use_certificate
 SSL_CTX_use_PrivateKey
 SSL_do_handshake
 SSL_free
 SSL_get0_alpn_selected
 SSL_get0_next_proto_negotiated
+SSL_get0_verified_chain
 SSL_get1_peer_certificate
 SSL_get1_session
 SSL_get_certificate
@@ -182,10 +191,12 @@ SSL_get_error
 SSL_get_ex_data
 SSL_get_ex_data_X509_STORE_CTX_idx
 SSL_get_options
+SSL_get_peer_cert_chain
 SSL_get_rbio
 SSL_get_servername
 SSL_get_session
 SSL_get_shutdown
+SSL_get_SSL_CTX
 SSL_get_verify_result
 SSL_get_version
 SSL_get_wbio
@@ -195,10 +206,17 @@ SSL_load_client_CA_file
 SSL_new
 SSL_read_early_data
 SSL_read
+SSL_read_early_data
 SSL_select_next_proto
+SSL_sendfile
 SSL_SESSION_free
 SSL_SESSION_get_id
+SSL_SESSION_get_time
+SSL_SESSION_get_timeout
 SSL_session_reused
+SSL_SESSION_set1_id_context
+SSL_SESSION_set_time
+SSL_SESSION_set_timeout
 SSL_SESSION_up_ref
 SSL_set_accept_state
 SSL_set_connect_state
@@ -211,11 +229,14 @@ SSL_set_shutdown
 SSL_set_SSL_CTX
 SSL_set_verify_depth
 SSL_set_verify
+SSL_set_verify_depth
 SSL_shutdown
 SSL_use_certificate
 SSL_use_PrivateKey
+SSL_version
 SSL_write_early_data
 SSL_write
+SSL_write_early_data
 TLS_method
 """.split())
 


### PR DESCRIPTION
I cheated a little bit and avoided spinning up a 24.04 vm with the Python tooling for this and installed matching versions from source. I think it's unlikely that a distro patch is adding new OpenSSL API surface :-)

Process was roughly:
* Cloning https://github.com/ctz/junk-drawer/tree/main/what-uses-libssl
* `echo '{}' > data.json; which-libssl-functions.py $BIN`
* `cat data.json | jq '.[][].sym' | sort | sed sed 's/\"//g'`
* Diff-ing in the new additions