### PR TITLE
Implement `SSL_CONF_cmd` `VerifyMode` command.

### DIFF
--- a/rustls-libssl/MATRIX.md
+++ b/rustls-libssl/MATRIX.md
@@ -379,7 +379,7 @@
 | `SSL_get_state`  |  |  | :white_check_mark: |
 | `SSL_get_verify_callback`  |  |  |  |
 | `SSL_get_verify_depth`  |  |  | :white_check_mark: |
-| `SSL_get_verify_mode`  |  |  |  |
+| `SSL_get_verify_mode`  |  |  | :white_check_mark: |
 | `SSL_get_verify_result`  | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | `SSL_get_version`  | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | `SSL_get_wbio`  |  | :white_check_mark: | :white_check_mark: |

--- a/rustls-libssl/build.rs
+++ b/rustls-libssl/build.rs
@@ -61,6 +61,7 @@ const ENTRYPOINTS: &[&str] = &[
     "SSL_clear_options",
     "SSL_CONF_cmd",
     "SSL_CONF_cmd_value_type",
+    "SSL_CONF_CTX_clear_flags",
     "SSL_CONF_CTX_finish",
     "SSL_CONF_CTX_free",
     "SSL_CONF_CTX_new",

--- a/rustls-libssl/build.rs
+++ b/rustls-libssl/build.rs
@@ -156,6 +156,7 @@ const ENTRYPOINTS: &[&str] = &[
     "SSL_get_SSL_CTX",
     "SSL_get_state",
     "SSL_get_verify_depth",
+    "SSL_get_verify_mode",
     "SSL_get_verify_result",
     "SSL_get_version",
     "SSL_get_wbio",

--- a/rustls-libssl/src/conf.rs
+++ b/rustls-libssl/src/conf.rs
@@ -6,7 +6,7 @@ use rustls::ProtocolVersion;
 
 use crate::error::Error;
 use crate::not_thread_safe::NotThreadSafe;
-use crate::{Ssl, SslContext};
+use crate::{Ssl, SslContext, VerifyMode};
 
 #[derive(Default)]
 pub(super) struct SslConfigCtx {
@@ -118,6 +118,57 @@ impl SslConfigCtx {
             }
             State::ApplyingToSsl(ssl) => {
                 ssl.get_mut().set_max_protocol_version(ver);
+                ActionResult::Applied
+            }
+        })
+    }
+
+    fn verify_mode(&mut self, raw_mode: Option<&str>) -> Result<ActionResult, Error> {
+        // If there's a SSL_CTX or SSL set then we want to mutate the existing verify_mode.
+        let mut verify_mode = match &self.state {
+            State::Validating => VerifyMode::default(),
+            State::ApplyingToSsl(ssl) => ssl.get().verify_mode,
+            State::ApplyingToCtx(ctx) => ctx.get().verify_mode,
+        };
+
+        let raw_mode = match raw_mode {
+            Some(raw_mode) => raw_mode,
+            None => return Ok(ActionResult::ValueRequired),
+        };
+
+        if !self.flags.is_server() && !self.flags.is_client() {
+            return Err(Error::bad_data("neither a client or a server"));
+        }
+
+        // "The value argument is a comma separated list of flags to set."
+        let mode_parts = raw_mode.split(',').collect::<Vec<&str>>();
+        for part in mode_parts {
+            match (part, self.flags.is_server()) {
+                // "Peer enables peer verification: for clients only."
+                ("Peer", false) => verify_mode.0 |= VerifyMode::PEER,
+                // "Request requests but does not require a certificate from the client.  Servers only."
+                ("Request", true) => verify_mode.0 |= VerifyMode::PEER,
+                // "Require requests and requires a certificate from the client: an error occurs if the
+                // client does not present a certificate. Servers only."
+                ("Require", true) => {
+                    verify_mode.0 |= VerifyMode::PEER | VerifyMode::FAIL_IF_NO_PEER_CERT
+                }
+                // We do not implement Once, RequestPostHandshake and RequiresPostHandshake,
+                // but don't error if provided.
+                ("Once" | "RequestPostHandshake" | "RequirePostHandshake", _) => {}
+                _ => return Err(Error::bad_data("unrecognized verify mode")),
+            }
+        }
+
+        Ok(match &self.state {
+            // OpenSSL returns "2" for this case...
+            State::Validating => ActionResult::Applied,
+            State::ApplyingToCtx(ctx) => {
+                ctx.get_mut().set_verify(verify_mode);
+                ActionResult::Applied
+            }
+            State::ApplyingToSsl(ssl) => {
+                ssl.get_mut().set_verify(verify_mode);
                 ActionResult::Applied
             }
         })
@@ -256,6 +307,8 @@ type CommandAction = fn(&mut SslConfigCtx, value: Option<&str>) -> Result<Action
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[repr(i32)]
 enum ActionResult {
+    /// The action required a value but was provided NULL.
+    ValueRequired = -3,
     /// The action value was recognized, but not applied.
     ///
     /// For example, if no `SSL_CTX` has been set a [`CommandAction`] may return `NotApplied` after
@@ -339,5 +392,12 @@ const SUPPORTED_COMMANDS: &[Command] = &[
         flags: Flags(Flags::ANY),
         value_type: ValueType::String,
         action: SslConfigCtx::max_protocol,
+    },
+    Command {
+        name_file: Some("VerifyMode"),
+        name_cmdline: None,
+        flags: Flags(Flags::ANY),
+        value_type: ValueType::String,
+        action: SslConfigCtx::verify_mode,
     },
 ];

--- a/rustls-libssl/src/conf.rs
+++ b/rustls-libssl/src/conf.rs
@@ -170,21 +170,17 @@ impl SslConfigCtx {
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[repr(i32)]
-#[allow(dead_code)] // TODO(XXX): Remove once other value types are used.
 pub(super) enum ValueType {
     /// The option is unrecognized.
     Unknown = 0x0,
     /// The option value is a string without any specific structure.
     String = 0x1,
-    /// The option value is a filename.
-    File = 0x2,
-    /// The option value is a directory name.
-    Dir = 0x3,
-    /// The option value is not used.
-    None = 0x4,
-    /// The option is an X509 store
-    // NOTE(XXX): This one is missing from the OpenSSL man pages.
-    Store = 0x5,
+    // The option value is a filename.
+    //File = 0x2,
+    // The option value is a directory name.
+    //Dir = 0x3,
+    // The option value is not used.
+    //None = 0x4,
 }
 
 impl From<ValueType> for c_int {
@@ -259,12 +255,12 @@ type CommandAction = fn(&mut SslConfigCtx, value: Option<&str>) -> Result<Action
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[repr(i32)]
-#[allow(dead_code)] // TODO(XXX): Remove with first usage of NotApplied.
 enum ActionResult {
     /// The action value was recognized, but not applied.
     ///
     /// For example, if no `SSL_CTX` has been set a [`CommandAction`] may return `NotApplied` after
     /// validating the command value.
+    #[allow(dead_code)] // TODO(XXX): remove with first ref.
     NotApplied = 1,
     /// The action value was recognized and applied.
     Applied = 2,
@@ -279,7 +275,6 @@ impl From<ActionResult> for c_int {
 #[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
 pub(super) struct Flags(c_uint);
 
-#[allow(dead_code)] // TODO(XXX): Remove once all flags are used.
 impl Flags {
     const ANY: c_uint = 0x0;
 
@@ -290,6 +285,7 @@ impl Flags {
     const SERVER: c_uint = 0x8;
     const SHOW_ERRORS: c_uint = 0x10;
     const CERTIFICATE: c_uint = 0x20;
+    #[allow(dead_code)] // TODO(XXX): Remove once REQUIRE_PRIVATE is used.
     const REQUIRE_PRIVATE: c_uint = 0x40;
 
     fn is_cmdline(&self) -> bool {
@@ -312,6 +308,7 @@ impl Flags {
         self.0 & Self::CERTIFICATE == Self::CERTIFICATE
     }
 
+    #[allow(dead_code)] // TODO(XXX): Remove once REQUIRE_PRIVATE is used.
     fn is_require_private(&self) -> bool {
         self.0 & Self::REQUIRE_PRIVATE == Self::REQUIRE_PRIVATE
     }

--- a/rustls-libssl/src/entry.rs
+++ b/rustls-libssl/src/entry.rs
@@ -1363,6 +1363,12 @@ entry! {
 }
 
 entry! {
+    pub fn _SSL_get_verify_mode(ssl: *const SSL) -> c_int {
+        try_clone_arc!(ssl).get().get_verify_mode().into()
+    }
+}
+
+entry! {
     pub fn _SSL_set_verify_depth(ssl: *mut SSL, depth: c_int) {
         try_clone_arc!(ssl).get_mut().set_verify_depth(depth)
     }

--- a/rustls-libssl/src/lib.rs
+++ b/rustls-libssl/src/lib.rs
@@ -890,6 +890,10 @@ impl Ssl {
         self.verify_mode = mode;
     }
 
+    fn get_verify_mode(&self) -> VerifyMode {
+        self.verify_mode
+    }
+
     fn set_verify_depth(&mut self, depth: c_int) {
         self.verify_depth = depth;
     }


### PR DESCRIPTION
This branch follows #29, extending the existing `SSL_CONF_xxx` API to support the "VerifyMode" sub-command. See [`man 3 SSL_CONF_cmd`](https://www.openssl.org/docs/man3.0/man3/SSL_CONF_cmd.html) & ctrl-f "VerifyMode" (_my kingdom for an anchor tag :roll_eyes:_), for more information.

Similar to the existing support for  `SSL_CTX_set_verify` and  `SSL_set_verify` we support `Peer`, `Request` and `Require` but not `Once`, `RequestPostHandshake` or `RequiresPostHandshake`. 

Along the way I also:

* Added a `SSL_CONF_CTX_clear_flags` entrypoint. The implementation landed in #29 but wasn't being demangled by the linker build script to expose it. It's now used in the `config.c` unit test so we won't regress by mistake.
* Added `SSL_get_verify_mode`. We already implemented `SSL_CTX_get_verify_mode` and had all the pieces
laying around for the `SSL` equiv. I also needed this for the update to the `config.c` unit tests.

There's no nginx integration test for this one because I believe we need https://github.com/rustls/rustls-openssl-compat/issues/15 to get that working.

Updates https://github.com/rustls/rustls-openssl-compat/issues/22
