### PR TITLE
Implement `SSL_CONF_cmd` `Certificate` and `PrivateKey` commands

### DIFF
--- a/rustls-libssl/tests/nginx_1_24.conf
+++ b/rustls-libssl/tests/nginx_1_24.conf
@@ -13,11 +13,15 @@ http {
     server {
        # Custom configuration w/ ssl_conf_command:
        #  * TLS 1.3 or greater only
+       #  * Certificate override of ssl_certificate
+       #  * PrivateKey override of ssl_certificate_key
        listen 8447 ssl;
-       ssl_certificate ../../../test-ca/rsa/server.cert;
-       ssl_certificate_key ../../../test-ca/rsa/server.key;
+       ssl_certificate ../../../test-ca/ed25519/server.cert;
+       ssl_certificate_key ../../../test-ca/ed25519/server.key;
        server_name localhost;
 
+       ssl_conf_command Certificate ../../../test-ca/rsa/server.cert;
+       ssl_conf_command PrivateKey ../../../test-ca/rsa/server.key;
        ssl_conf_command MinProtocol TLSv1.3;
 
        location = / {

--- a/rustls-libssl/tests/runner.rs
+++ b/rustls-libssl/tests/runner.rs
@@ -613,6 +613,8 @@ fn nginx_1_24() {
         35
     );
     // TLS 1.3 to the TLS 1.3 only port should succeed.
+    // The RSA CA cert should allow verification to succeed, showing the overrides of
+    // the ED25519 ssl_certificate/ssl_certificate_key directives worked.
     assert_eq!(
         Command::new("curl")
             .env("LD_LIBRARY_PATH", "")


### PR DESCRIPTION
This branch follows https://github.com/rustls/rustls-openssl-compat/pull/29,  https://github.com/rustls/rustls-openssl-compat/pull/31  extending the existing `SSL_CONF_xxx` API to support the "Certificate" and "PrivateKey" sub-commands. See [`man 3 SSL_CONF_cmd`](https://www.openssl.org/docs/man3.0/man3/SSL_CONF_cmd.html) for more information. 

We diverge slightly from the upstream here by re-using the existing `SSL_CTX_use_certificate_chain_file` and `SSL_CTX_use_PrivateKey_file` logic. In the case of `SSL_CTX_use_certificate_chain_file` this means pulling out a `use_cert_chain_file` helper with the existing logic so it can be reused. Taking this approach requires the minimum amount of fuss to support these configuration commands, but means we error earlier in the case of the cert file/private key being bogus. This seems better to me than putting in more extra design work just to delay erroring! Relatedly, we don't have all the pieces needed to support setting a certificate chain by PEM input path for a `SSL`, just a `SSL_CTX`, so we skip implementing `Certificate` after `SSL_CONF_CTX_set_ssl` - in practice Nginx only uses `SSL_CONF_CTX_set_ssl_ctx` so we can punt here for the time being.

An integration test using Nginx's `ssl_conf_command` directive to override the normal `ssl_certificate` and `ssl_certificate_key` directives using the `Certificate` and `PrivateKey` commands demonstrates the end-to-end implementation working w/ Nginx 1.24+.

Updates https://github.com/rustls/rustls-openssl-compat/issues/22
