### PR TITLE
disable nginx session tickets for resumption test

### DIFF
--- a/rustls-libssl/tests/nginx.conf
+++ b/rustls-libssl/tests/nginx.conf
@@ -102,6 +102,11 @@ http {
         # per-server resumption
         listen 8446 ssl;
         ssl_session_cache shared:port8446:1M;
+        # We don't presently support session tickets and on nginx 1.23.2+ the "shared"
+        # ssl_session_cache is also used to generate, store, and rotate TLS session
+        # ticket keys. With this enabled, the 'shared' cache will not function.
+        # TODO(XXX): revisit with ticket support, https://github.com/rustls/rustls-openssl-compat/issues/30
+        ssl_session_tickets off;
         ssl_certificate ../../../test-ca/rsa/server.cert;
         ssl_certificate_key ../../../test-ca/rsa/server.key;
         server_name localhost;

--- a/rustls-libssl/tests/runner.rs
+++ b/rustls-libssl/tests/runner.rs
@@ -502,42 +502,37 @@ fn nginx() {
         b"hello world\n"
     );
 
-    // TODO(XXX): Session resumption is not working w/ nginx 1.24.0+
-    //   Until this is fixed skip the resumption specific tests with
-    //   newer Nginx versions.
-    if matches!(nginx_version(), (1, minor) if minor < 24) {
-        for (port, reused) in [(8443, '.'), (8444, 'r'), (8445, 'r'), (8446, 'r')] {
-            // multiple requests without http connection reuse
-            // (second should be a TLS resumption if possible)
-            assert_eq!(
-                Command::new("curl")
-                    .env("LD_LIBRARY_PATH", "")
-                    .args([
-                        "--verbose",
-                        "--cacert",
-                        "test-ca/rsa/ca.cert",
-                        "-H",
-                        "connection: close",
-                        &format!("https://localhost:{port}/"),
-                        &format!("https://localhost:{port}/ssl-agreed"),
-                        &format!("https://localhost:{port}/ssl-server-name"),
-                        &format!("https://localhost:{port}/ssl-was-reused")
-                    ])
-                    .stdout(Stdio::piped())
-                    .output()
-                    .map(print_output)
-                    .unwrap()
-                    .stdout,
-                format!(
-                    "hello world\n\
+    for (port, reused) in [(8443, '.'), (8444, 'r'), (8445, 'r'), (8446, 'r')] {
+        // multiple requests without http connection reuse
+        // (second should be a TLS resumption if possible)
+        assert_eq!(
+            Command::new("curl")
+                .env("LD_LIBRARY_PATH", "")
+                .args([
+                    "--verbose",
+                    "--cacert",
+                    "test-ca/rsa/ca.cert",
+                    "-H",
+                    "connection: close",
+                    &format!("https://localhost:{port}/"),
+                    &format!("https://localhost:{port}/ssl-agreed"),
+                    &format!("https://localhost:{port}/ssl-server-name"),
+                    &format!("https://localhost:{port}/ssl-was-reused")
+                ])
+                .stdout(Stdio::piped())
+                .output()
+                .map(print_output)
+                .unwrap()
+                .stdout,
+            format!(
+                "hello world\n\
                      protocol:TLSv1.3,cipher:TLS_AES_256_GCM_SHA384\n\
                      server-name:localhost\n\
                      reused:{reused}\n"
-                )
-                .as_bytes(),
-            );
-            println!("PASS: resumption test for port={port} reused={reused}");
-        }
+            )
+            .as_bytes(),
+        );
+        println!("PASS: resumption test for port={port} reused={reused}");
     }
 
     // big download (throttled by curl to ensure non-blocking writes work)


### PR DESCRIPTION
With Nginx 1.24.0 we saw a regression in the runner `nginx` test when checking that session resumption worked as expected with a `curl` client (https://github.com/rustls/rustls-openssl-compat/issues/30). This branch fixes the issue by disabling `ssl_session_tickets` for the server config using `ssl_session_cache shared:...` (port 8446).

Since Nginx 1.23.2 (https://github.com/nginx/nginx/commit/1d572e359a210dcb27e5e073c016c1768c435263), the `shared` session cache has done double duty, also managing generating, storing, and updating TLS session ticket keys. This is done primarily with the OpenSSL
`SSL_CTX_set_tlsext_ticket_key_cb`/`SSL_CTX_set_tlsext_ticket_key_evp_cb` APIs, which we don't yet support. We're also not setting a ticketer for the Rustls `ServerConfig` we construct.

The net result is that when using our compat shim with Nginx 1.23.2+ we need to explicitly disable session ticket support in order for the `shared` session cache to work the way we expect for classic sessions.

Separately, we should investigate proper session ticket support. In the meantime this restores the testing we intended to be happening and clarifies where the limitation is.

Updates #30 