### PR TITLE
0.2.1 release preparation

### DIFF
--- a/rustls-libssl/Cargo.lock
+++ b/rustls-libssl/Cargo.lock
@@ -428,7 +428,7 @@ dependencies = [
 
 [[package]]
 name = "rustls-libssl"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "env_logger",
  "log",

--- a/rustls-libssl/Cargo.toml
+++ b/rustls-libssl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustls-libssl"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 build = "build.rs"
 rust-version = "1.77"


### PR DESCRIPTION
Releasing the [changes since 0.2.0](https://github.com/rustls/rustls-openssl-compat/compare/v/0.2.0...de4eb6e).

## Proposed release notes

* Added initial support for the `SSL_CONF_*` API family and a subset of the available configuration commands. This allows use of the `ssl_conf_command` Nginx 1.19.4+ directive.
* Added initial support for TLS session tickets and associated APIs for disabling their use, and configuring the number of tickets sent to a peer.