### PR TITLE
Rustls 0.23.11, X509_check_private_key, SSL_get_negotiated_group

### DIFF
--- a/rustls-libssl/Cargo.lock
+++ b/rustls-libssl/Cargo.lock
@@ -413,9 +413,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.10"
+version = "0.23.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05cff451f60db80f490f3c182b77c35260baace73209e9cdbbe526bfe3a4d402"
+checksum = "4828ea528154ae444e5a642dbb7d5623354030dc9822b83fd9bb79683c7399d0"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -456,9 +456,9 @@ checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.4"
+version = "0.102.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
+checksum = "f9a6fccd794a42c2c105b513a2f62bc3fd8f3ba57a4593677ceb0bd035164d78"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/rustls-libssl/build.rs
+++ b/rustls-libssl/build.rs
@@ -214,4 +214,5 @@ const ENTRYPOINTS: &[&str] = &[
     "TLS_client_method",
     "TLS_method",
     "TLS_server_method",
+    "X509_check_private_key",
 ];

--- a/rustls-libssl/src/constants.rs
+++ b/rustls-libssl/src/constants.rs
@@ -1,10 +1,10 @@
 use core::ffi::{c_int, CStr};
 use openssl_sys::{
     NID_X9_62_prime256v1, NID_rsaEncryption, NID_rsassaPss, NID_secp384r1, NID_secp521r1,
-    NID_ED25519, NID_ED448,
+    NID_ED25519, NID_ED448, NID_X25519, NID_X448,
 };
 
-use rustls::{AlertDescription, SignatureScheme};
+use rustls::{AlertDescription, NamedGroup, SignatureScheme};
 
 pub fn alert_desc_to_long_string(value: c_int) -> &'static CStr {
     match AlertDescription::from(value as u8) {
@@ -99,6 +99,37 @@ pub fn sig_scheme_to_nid(scheme: SignatureScheme) -> Option<c_int> {
         ED25519 => Some(NID_ED25519),
         ED448 => Some(NID_ED448),
         // Omitted: SHA1 legacy schemes.
+        _ => None,
+    }
+}
+
+pub fn named_group_to_nid(group: NamedGroup) -> Option<c_int> {
+    use NamedGroup::*;
+
+    // See NID_ffhdhe* from obj_mac.h - openssl-sys does not have
+    // constants for these to import.
+    const NID_FFDHE2048: c_int = 1126;
+    const NID_FFDHE3072: c_int = 1127;
+    const NID_FFDHE4096: c_int = 1128;
+    const NID_FFDHE6144: c_int = 1129;
+    const NID_FFDHE8192: c_int = 1130;
+
+    // See TLSEXT_nid_unknown from tls1.h - openssl-sys does not
+    // have a constant for this to import.
+    const TLSEXT_NID_UNKNOWN: c_int = 0x1000000;
+
+    match group {
+        secp256r1 => Some(NID_X9_62_prime256v1),
+        secp384r1 => Some(NID_secp384r1),
+        secp521r1 => Some(NID_secp521r1),
+        X25519 => Some(NID_X25519),
+        X448 => Some(NID_X448),
+        FFDHE2048 => Some(NID_FFDHE2048),
+        FFDHE3072 => Some(NID_FFDHE3072),
+        FFDHE4096 => Some(NID_FFDHE4096),
+        FFDHE6144 => Some(NID_FFDHE6144),
+        FFDHE8192 => Some(NID_FFDHE8192),
+        Unknown(id) => Some(TLSEXT_NID_UNKNOWN | id as c_int),
         _ => None,
     }
 }

--- a/rustls-libssl/src/lib.rs
+++ b/rustls-libssl/src/lib.rs
@@ -12,7 +12,7 @@ use openssl_sys::{
     X509_STORE, X509_V_ERR_UNSPECIFIED,
 };
 use rustls::client::Resumption;
-use rustls::crypto::aws_lc_rs as provider;
+use rustls::crypto::{aws_lc_rs as provider, SupportedKxGroup};
 use rustls::pki_types::{CertificateDer, ServerName};
 use rustls::server::{Accepted, Acceptor, ProducesTickets};
 use rustls::{
@@ -1376,6 +1376,11 @@ impl Ssl {
         self.conn()
             .and_then(|conn| conn.negotiated_cipher_suite())
             .map(|suite| suite.suite())
+    }
+
+    fn get_negotiated_key_exchange_group(&self) -> Option<&'static dyn SupportedKxGroup> {
+        self.conn()
+            .and_then(|conn| conn.negotiated_key_exchange_group())
     }
 
     fn get_last_verification_result(&self) -> i64 {

--- a/rustls-libssl/src/sign.rs
+++ b/rustls-libssl/src/sign.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use openssl_sys::{EVP_PKEY, X509};
 use rustls::client::ResolvesClientCert;
-use rustls::pki_types::CertificateDer;
+use rustls::pki_types::{CertificateDer, SubjectPublicKeyInfoDer};
 use rustls::server::{ClientHello, ResolvesServerCert};
 use rustls::sign;
 use rustls::{SignatureAlgorithm, SignatureScheme};
@@ -88,19 +88,39 @@ impl CertifiedKeySet {
 }
 
 #[derive(Clone, Debug)]
-struct OpenSslCertifiedKey {
+pub(super) struct OpenSslCertifiedKey {
     key: EvpPkey,
     openssl_chain: OwnedX509Stack,
     rustls_chain: Vec<CertificateDer<'static>>,
 }
 
 impl OpenSslCertifiedKey {
-    fn new(chain: Vec<CertificateDer<'static>>, key: EvpPkey) -> Result<Self, error::Error> {
+    pub(super) fn new(
+        chain: Vec<CertificateDer<'static>>,
+        key: EvpPkey,
+    ) -> Result<Self, error::Error> {
         Ok(Self {
             key,
             openssl_chain: OwnedX509Stack::from_rustls(&chain)?,
             rustls_chain: chain,
         })
+    }
+
+    pub(super) fn keys_match(&self) -> bool {
+        match sign::CertifiedKey::new(
+            self.rustls_chain.clone(),
+            Arc::new(OpenSslKey(self.key.clone())),
+        )
+        .keys_match()
+        {
+            // Note: we allow "Unknown" to be treated as success here. This is returned
+            //   when it wasn't possible to get the SPKI for the private key, and so we
+            //   aren't certain if it matches or not.
+            Ok(()) | Err(rustls::Error::InconsistentKeys(rustls::InconsistentKeys::Unknown)) => {
+                true
+            }
+            _ => false,
+        }
     }
 
     fn borrow_cert(&self) -> *mut X509 {
@@ -243,6 +263,12 @@ impl sign::SigningKey for OpenSslKey {
             }
             _ => None,
         }
+    }
+
+    fn public_key(&self) -> Option<SubjectPublicKeyInfoDer<'_>> {
+        Some(SubjectPublicKeyInfoDer::from(
+            self.0.subject_public_key_info(),
+        ))
     }
 
     fn algorithm(&self) -> SignatureAlgorithm {

--- a/rustls-libssl/tests/client.c
+++ b/rustls-libssl/tests/client.c
@@ -131,6 +131,7 @@ int main(int argc, char **argv) {
   TRACE(SSL_get_peer_signature_type_nid(ssl, &cipher_nid));
   dump_openssl_error_stack();
   printf("cipher NID: %d\n", cipher_nid);
+  printf("negotiated group NID: %ld\n", SSL_get_negotiated_group(ssl));
 
   show_peer_certificate("server", ssl);
 

--- a/rustls-libssl/tests/client.c
+++ b/rustls-libssl/tests/client.c
@@ -79,6 +79,7 @@ int main(int argc, char **argv) {
     TRACE(SSL_CTX_use_PrivateKey_file(ctx, keyfile, SSL_FILETYPE_PEM));
     client_key = SSL_CTX_get0_privatekey(ctx);
     client_cert = SSL_CTX_get0_certificate(ctx);
+    TRACE(X509_check_private_key(client_cert, client_key));
   }
 
   TRACE(SSL_CTX_set_alpn_protos(ctx, (const uint8_t *)"\x02hi\x05world", 9));

--- a/rustls-libssl/tests/server.c
+++ b/rustls-libssl/tests/server.c
@@ -184,6 +184,7 @@ int main(int argc, char **argv) {
   TRACE(SSL_CTX_use_PrivateKey_file(ctx, keyfile, SSL_FILETYPE_PEM));
   server_key = SSL_CTX_get0_privatekey(ctx);
   server_cert = SSL_CTX_get0_certificate(ctx);
+  TRACE(X509_check_private_key(server_cert, server_key));
 
   printf("SSL_CTX_get_max_early_data default %lu\n",
          (unsigned long)SSL_CTX_get_max_early_data(ctx));

--- a/rustls-libssl/tests/server.c
+++ b/rustls-libssl/tests/server.c
@@ -228,6 +228,7 @@ int main(int argc, char **argv) {
   TRACE(SSL_get_peer_signature_type_nid(ssl, &cipher_nid));
   dump_openssl_error_stack();
   printf("cipher NID: %d\n", cipher_nid);
+  printf("negotiated group NID: %ld\n", SSL_get_negotiated_group(ssl));
 
   printf("SSL_get_servername: %s (%d)\n",
          SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name),


### PR DESCRIPTION
This branch updates the Rustls version from 0.23.10 to [0.23.11](https://github.com/rustls/rustls/releases/tag/v%2F0.23.11), and uses some of the newly added APIs to add initial implementations for [`X509_check_private_key`](https://www.openssl.org/docs/man3.0/man3/X509_check_private_key.html) and [`SSL_get_negotiated_group`](https://www.openssl.org/docs/man3.0/man3/SSL_get_negotiated_group.html).

### implement X509_check_private_key

Rustls 0.23.11 added a `keys_match()` function to `CertifiedKey` instances. This commit uses that new capability to implement `X509_check_private_key()`. The `EvpPkey` and `OpenSslKey` key types are both updated to enable implementing the new `sign::SigningKey` trait's optional `public_key()` fn.

Following the precedent set upstream in Rustls we're permissive if we can't determine a key's SPKI and return `C_INT_SUCCESS` in this case.

### implement SSL_get_negotiated_group

Rustls 0.23.11 added a `negotiated_key_exchange_group()` to connections that exposes the `&dyn SupportedKxGroup` used by the connection. This allows us to implement `SSL_get_negotiated_group()`.

Our implementation differs slightly from the upstream w.r.t what NID we return for resumed connections. Rustls will return `None` (which we translate to `NID_undef`) for connections that are still handshaking, or for resumed TLS 1.2 handshakes. In contrast, OpenSSL returns the negotiated group of the original connection in that latter case.

There's no new entry point for this function because like so much of the OpenSSL API it backs onto `SSL_ctrl` :face_exhaling: 