### PR TITLE
Add NixOS packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target
+result

--- a/dist/package.nix
+++ b/dist/package.nix
@@ -1,0 +1,47 @@
+{ lib, stdenv, llvmPackages, rustPlatform, pkg-config, openssl }:
+let
+  target = stdenv.hostPlatform.rust.rustcTargetSpec;
+  libExt = stdenv.hostPlatform.extensions.sharedLibrary;
+in
+  rustPlatform.buildRustPackage {
+    name = "rustls-libssl";
+
+    src = ../.;
+    cargoLock.lockFile = ../Cargo.lock;
+
+    nativeBuildInputs = [
+      pkg-config # for openssl-sys
+      llvmPackages.lld # see build.rs
+    ];
+    buildInputs = [
+      openssl
+    ];
+
+    doCheck = false; # TODO: can't find libcrypto
+
+    outputs = [ "out" "dev" ];
+    installPhase = ''
+      mkdir -p $out/lib $dev/lib/pkgconfig
+
+      mv target/${target}/release/libssl${libExt} $out/lib/libssl${libExt}.3
+      ln -s libssl${libExt}.3 $out/lib/libssl${libExt}
+
+      ln -s ${openssl.out}/lib/libcrypto${libExt}.3 $out/lib/
+      ln -s libcrypto${libExt}.3 $out/lib/libcrypto${libExt}
+
+      if [[ -e ${openssl.out}/lib/engines-3 ]]; then
+        ln -s ${openssl.out}/lib/engines-3 $out/lib/
+      fi
+      if [[ -e ${openssl.out}/lib/ossl-modules ]]; then
+        ln -s ${openssl.out}/lib/ossl-modules $out/lib/
+      fi
+
+      ln -s ${openssl.dev}/include $dev/
+
+      cp ${openssl.dev}/lib/pkgconfig/*.pc $dev/lib/pkgconfig/
+      sed -i \
+        -e "s|${openssl.out}|$out|g" \
+        -e "s|${openssl.dev}|$dev|g" \
+        $dev/lib/pkgconfig/*.pc
+    '';
+  }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,7 @@
+{
+  outputs = { ... }: {
+    overlays.default = final: prev: {
+      rustls-libssl = final.callPackage ./dist/package.nix { };
+    };
+  };
+}

--- a/tests/nixos.nix
+++ b/tests/nixos.nix
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: MIT
+
+# Derived from:
+# https://github.com/NixOS/nixpkgs/blob/4c9ca53890654b5e2fbb22ab8feb1842d81e01c1/nixos/tests/nginx-http3.nix
+# Copyright (c) 2003-2024 Eelco Dolstra and the Nixpkgs/NixOS contributors
+
+{ pkgs ? import <nixpkgs> { } }:
+
+let
+
+  caCert = builtins.readFile <nixpkgs/nixos/tests/common/acme/server/ca.cert.pem>;
+  certPath = <nixpkgs/nixos/tests/common/acme/server/acme.test.cert.pem>;
+  keyPath = <nixpkgs/nixos/tests/common/acme/server/acme.test.key.pem>;
+
+  hosts = ''
+    192.168.2.101 acme.test
+  '';
+
+in
+
+pkgs.testers.runNixOSTest {
+  name = "rustls-libssl";
+
+  nodes = {
+    server = { lib, pkgs, ... }: {
+      networking = {
+        interfaces.eth1 = {
+          ipv4.addresses = [
+            { address = "192.168.2.101"; prefixLength = 24; }
+          ];
+        };
+        extraHosts = hosts;
+        firewall.allowedTCPPorts = [ 443 ];
+        firewall.allowedUDPPorts = [ 443 ];
+      };
+
+      security.pki.certificates = [ caCert ];
+
+      services.nginx = {
+        enable = true;
+        package = pkgs.nginxQuic.override {
+          modules = [ ];
+          openssl = pkgs.callPackage ../dist/package.nix { };
+        };
+
+        # Hardcoded sole input accepted by rustls-libssl.
+        sslCiphers = "HIGH:!aNULL:!MD5";
+
+        virtualHosts."acme.test" = {
+          onlySSL = true;
+          sslCertificate = certPath;
+          sslCertificateKey = keyPath;
+          http2 = true;
+          # TODO: Needs SSL_CTX_add_custom_ext
+          #http3 = true;
+          #http3_hq = false;
+          #quic = true;
+          reuseport = true;
+          root = lib.mkForce (pkgs.runCommandLocal "testdir" {} ''
+            mkdir "$out"
+            cat > "$out/index.html" <<EOF
+            <html><body>Hello World!</body></html>
+            EOF
+          '');
+        };
+      };
+    };
+
+    client = { pkgs, ... }: {
+      environment.systemPackages = [ pkgs.curlHTTP3 ];
+      networking = {
+        interfaces.eth1 = {
+          ipv4.addresses = [
+            { address = "192.168.2.201"; prefixLength = 24; }
+          ];
+        };
+        extraHosts = hosts;
+      };
+
+      security.pki.certificates = [ caCert ];
+    };
+  };
+
+  testScript = ''
+    start_all()
+    server.wait_for_open_port(443)
+    client.succeed("curl --verbose --http1.1 https://acme.test | grep 'Hello World!'")
+    client.succeed("curl --verbose --http2-prior-knowledge https://acme.test | grep 'Hello World!'")
+    #client.succeed("curl --verbose --http3-only https://acme.test | grep 'Hello World!'")
+  '';
+}


### PR DESCRIPTION
I'm not sure if this is useful to land here / something we'd want to maintain here, but I thought I'd open a draft PR to al least share the idea.

This adds a `dist/package.nix` containing a Nix package definition. We can't just swap out libssl on NixOS, so this recreates a typical install, reusing the OpenSSL libcrypto and headers via symlinks.

The `flake.nix` is optional convenience for consuming the git repo as a dependency.

I derived an automated integration test with Nginx based on a test from the NixOS repo. With Nix installed, you can run this with `nix-build tests/nixos.nix`.

Turns out HTTP/3 doesn't yet work, though. 🤷 