### PR TITLE
Fix CI packaging, format

### DIFF
--- a/.github/workflows/libssl.yaml
+++ b/.github/workflows/libssl.yaml
@@ -20,8 +20,7 @@ jobs:
           - stable
           - beta
           - nightly
-        # TODO(XXX): consider replacing ubuntu-24.04 w/ ubuntu-latest when appropriate
-        os: [ubuntu-24.04, ubuntu-22.04]
+        os: [ubuntu-latest, ubuntu-22.04]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -173,7 +172,7 @@ jobs:
 
   packaging:
     name: Packaging
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/tests/config.c
+++ b/tests/config.c
@@ -359,7 +359,7 @@ void test_verify_ca_path_file(void) {
   SSL_CTX_free(ctx);
 }
 
-#define NO_TICKET_SET(X) (((X)&SSL_OP_NO_TICKET) == SSL_OP_NO_TICKET)
+#define NO_TICKET_SET(X) (((X) & SSL_OP_NO_TICKET) == SSL_OP_NO_TICKET)
 
 void test_no_ticket(void) {
   SSL_CONF_CTX *cctx = SSL_CONF_CTX_new();


### PR DESCRIPTION
Fixes [the packaging build failure](https://github.com/rustls/rustls-openssl-compat/actions/runs/12393357037/job/34594433420) on `main`:

> nginx: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by /usr/lib/x86_64-linux-gnu/rustls-libssl/libssl.so.3)

As well as the [clang-format error](https://github.com/rustls/rustls-openssl-compat/actions/runs/12393357037/job/34594431439).

Also complete a TODO to replace 24.04 with ubuntu-latest.

