### PR TITLE
SSL_CIPHER_find: heed new nightly clippy warning

### DIFF
--- a/src/entry.rs
+++ b/src/entry.rs
@@ -1470,7 +1470,7 @@ type SSL_CIPHER = crate::SslCipher;
 entry! {
     pub fn _SSL_CIPHER_find(_ssl: *const SSL, ptr: *const c_uchar) -> *const SSL_CIPHER {
         let slice = try_slice!(ptr, 2);
-        let id = (slice[0] as u16) << 8 | (slice[1] as u16);
+        let id = ((slice[0] as u16) << 8) | (slice[1] as u16);
         crate::SslCipher::find_by_id(rustls::CipherSuite::from(id))
             .map(|cipher| cipher as *const SSL_CIPHER)
             .unwrap_or_else(ptr::null)


### PR DESCRIPTION
```
warning: operator precedence can trip the unwary
    --> src/entry.rs:1473:18
     |
1473 |         let id = (slice[0] as u16) << 8 | (slice[1] as u16);
     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider parenthesizing your expression: `((slice[0] as u16) << 8) | (slice[1] as u16)`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#precedence
     = note: `#[warn(clippy::precedence)]` on by default
```