### PR TITLE
Fix and rename `sig_scheme_to_nid`

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,7 +1,7 @@
 use core::ffi::{c_int, CStr};
 use openssl_sys::{
-    NID_X9_62_prime256v1, NID_rsaEncryption, NID_rsassaPss, NID_secp384r1, NID_secp521r1,
-    NID_ED25519, NID_ED448, NID_X25519, NID_X448,
+    NID_X9_62_id_ecPublicKey, NID_X9_62_prime256v1, NID_rsaEncryption, NID_rsassaPss,
+    NID_secp384r1, NID_secp521r1, NID_ED25519, NID_ED448, NID_X25519, NID_X448,
 };
 
 use rustls::{AlertDescription, NamedGroup, SignatureScheme};
@@ -88,14 +88,14 @@ pub fn alert_desc_to_short_string(value: c_int) -> &'static CStr {
     }
 }
 
-pub fn sig_scheme_to_nid(scheme: SignatureScheme) -> Option<c_int> {
+pub fn sig_scheme_to_type_nid(scheme: SignatureScheme) -> Option<c_int> {
     use SignatureScheme::*;
     match scheme {
         RSA_PKCS1_SHA256 | RSA_PKCS1_SHA384 | RSA_PKCS1_SHA512 => Some(NID_rsaEncryption),
         RSA_PSS_SHA256 | RSA_PSS_SHA384 | RSA_PSS_SHA512 => Some(NID_rsassaPss),
-        ECDSA_NISTP256_SHA256 => Some(NID_X9_62_prime256v1),
-        ECDSA_NISTP384_SHA384 => Some(NID_secp384r1),
-        ECDSA_NISTP521_SHA512 => Some(NID_secp521r1),
+        ECDSA_NISTP256_SHA256 | ECDSA_NISTP384_SHA384 | ECDSA_NISTP521_SHA512 => {
+            Some(NID_X9_62_id_ecPublicKey)
+        }
         ED25519 => Some(NID_ED25519),
         ED448 => Some(NID_ED448),
         // Omitted: SHA1 legacy schemes.

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -17,7 +17,7 @@ use rustls::pki_types::{CertificateDer, PrivatePkcs8KeyDer};
 
 use crate::bio::{Bio, BIO, BIO_METHOD};
 use crate::callbacks::SslCallbackContext;
-use crate::constants::{named_group_to_nid, sig_scheme_to_nid};
+use crate::constants::{named_group_to_nid, sig_scheme_to_type_nid};
 use crate::error::{ffi_panic_boundary, Error, MysteriouslyOppositeReturnValue};
 use crate::evp_pkey::EvpPkey;
 use crate::ex_data::ExData;
@@ -1192,7 +1192,7 @@ entry! {
         let sigalg_nid = try_clone_arc!(ssl)
             .get()
             .get_last_verification_sig_scheme()
-            .and_then(sig_scheme_to_nid);
+            .and_then(sig_scheme_to_type_nid);
 
         match sigalg_nid {
             Some(nid) => {


### PR DESCRIPTION
This recently started failing in the `client_real_world` test, as the server switched to an ECDSA cert chain.

This PR aims to fix https://github.com/rustls/rustls-openssl-compat/actions/runs/12788674948