### PR TITLE
Fix Fedora package tests

### DIFF
--- a/.github/workflows/libssl.yaml
+++ b/.github/workflows/libssl.yaml
@@ -8,7 +8,7 @@ on:
   pull_request:
   merge_group:
   schedule:
-    - cron: '15 12 * * 3'
+    - cron: '15 12 * * *'
 
 jobs:
   build:

--- a/MATRIX.md
+++ b/MATRIX.md
@@ -219,7 +219,7 @@
 | `SSL_SESSION_free`  | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | `SSL_SESSION_get0_alpn_selected`  |  |  |  |
 | `SSL_SESSION_get0_cipher`  |  |  |  |
-| `SSL_SESSION_get0_hostname`  |  |  |  |
+| `SSL_SESSION_get0_hostname`  |  |  | :exclamation: [^stub] |
 | `SSL_SESSION_get0_id_context`  |  |  |  |
 | `SSL_SESSION_get0_peer`  |  |  |  |
 | `SSL_SESSION_get0_ticket`  |  |  |  |

--- a/build.rs
+++ b/build.rs
@@ -178,6 +178,7 @@ const ENTRYPOINTS: &[&str] = &[
     "SSL_select_next_proto",
     "SSL_sendfile",
     "SSL_SESSION_free",
+    "SSL_SESSION_get0_hostname",
     "SSL_SESSION_get_id",
     "SSL_SESSION_get_time",
     "SSL_SESSION_get_timeout",

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -2216,6 +2216,12 @@ type SSL_custom_ext_free_cb_ex = Option<
     ),
 >;
 
+// TODO: this could be implemented accurately by storing the SNI
+// of the originating connection (but only for TLS1.2) in the `SslSession`
+entry_stub! {
+    pub fn _SSL_SESSION_get0_hostname(_sess: *const SSL_SESSION) -> *const c_char;
+}
+
 // ---------------------
 
 #[cfg(test)]


### PR DESCRIPTION
Due to CVE-2025-23419 fedora's nginx now calls `SSL_SESSION_get0_hostname` to learn the session's original SNI value.  Stub it out.

Should fix https://github.com/rustls/rustls-openssl-compat/actions/runs/13544303491