### PR TITLE
Improve reliability of `server_key_algorithms` test

### DIFF
--- a/tests/helpers.h
+++ b/tests/helpers.h
@@ -17,6 +17,8 @@ static int trace(int rc, const char *str) {
 static int require(int expect_rc, int got_rc, const char *str) {
   if (expect_rc != got_rc) {
     printf("REQUIRED(%s) failed: wanted=%d, got=%d\n", str, expect_rc, got_rc);
+    fflush(stdout);
+    fflush(stderr);
     abort();
   }
   return got_rc;

--- a/tests/runner.rs
+++ b/tests/runner.rs
@@ -485,16 +485,61 @@ fn server_with_key_algorithm(key_type: &str, sig_algs: &str, version_flag: &str)
 
 #[test]
 #[ignore]
-fn server_key_algorithms() {
+fn server_key_algorithm_rsa_pss_rsae_sha256() {
     server_with_key_algorithm("rsa", "rsa_pss_rsae_sha256", "-tls1_3");
+}
+
+#[test]
+#[ignore]
+fn server_key_algorithm_rsa_pss_rsae_sha384() {
     server_with_key_algorithm("rsa", "rsa_pss_rsae_sha384", "-tls1_3");
+}
+
+#[test]
+#[ignore]
+fn server_key_algorithm_rsa_pss_rsae_sha512() {
     server_with_key_algorithm("rsa", "rsa_pss_rsae_sha512", "-tls1_3");
+}
+
+#[test]
+#[ignore]
+fn server_key_algorithm_rsa_pkcs1_sha256() {
     server_with_key_algorithm("rsa", "rsa_pkcs1_sha256", "-tls1_2");
+}
+
+#[test]
+#[ignore]
+fn server_key_algorithm_rsa_pkcs1_sha384() {
     server_with_key_algorithm("rsa", "rsa_pkcs1_sha384", "-tls1_2");
+}
+
+#[test]
+#[ignore]
+fn server_key_algorithm_rsa_pkcs1_sha512() {
     server_with_key_algorithm("rsa", "rsa_pkcs1_sha512", "-tls1_2");
+}
+
+#[test]
+#[ignore]
+fn server_key_algorithm_ed25519() {
     server_with_key_algorithm("ed25519", "ed25519", "-tls1_3");
+}
+
+#[test]
+#[ignore]
+fn server_key_algorithm_ecdsa_secp256r1_sha256() {
     server_with_key_algorithm("ecdsa-p256", "ecdsa_secp256r1_sha256", "-tls1_3");
+}
+
+#[test]
+#[ignore]
+fn server_key_algorithm_ecdsa_secp384r1_sha384() {
     server_with_key_algorithm("ecdsa-p384", "ecdsa_secp384r1_sha384", "-tls1_3");
+}
+
+#[test]
+#[ignore]
+fn server_key_algorithm_ecdsa_secp521r1_sha512() {
     server_with_key_algorithm("ecdsa-p521", "ecdsa_secp521r1_sha512", "-tls1_3");
 }
 

--- a/tests/server.c
+++ b/tests/server.c
@@ -116,7 +116,9 @@ int main(int argc, char **argv) {
   us.sin_port = htons(atoi(port));
   REQUIRE(0, bind(listener, (struct sockaddr *)&us, sizeof(us)));
   REQUIRE(0, listen(listener, 5));
-  printf("listening\n");
+  socklen_t us_len = sizeof(us);
+  REQUIRE(0, getsockname(listener, (struct sockaddr *)&us, &us_len));
+  printf("listening on %d\n", ntohs(us.sin_port));
   fflush(stdout);
   socklen_t them_len = sizeof(them);
   int sock = TRACE(accept(listener, (struct sockaddr *)&them, &them_len));


### PR DESCRIPTION
The root cause here was the test runner choosing a port for the test servers to run on, but losing when that port was used by something else.  Now the test server relies on the kernel to choose a free port.

fixes #37 