### PR TITLE
Fix nightly `clippy::uninlined_format_args`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -14,10 +14,7 @@ fn main() {
         for symbol in ENTRYPOINTS {
             // Rename underscore-prefixed symbols (produced by rust code) to
             // unprefixed symbols (manipulated by our version file).
-            println!(
-                "cargo:rustc-cdylib-link-arg=-Wl,--defsym={}=_{}",
-                symbol, symbol
-            );
+            println!("cargo:rustc-cdylib-link-arg=-Wl,--defsym={symbol}=_{symbol}",);
         }
     }
 }


### PR DESCRIPTION
re https://github.com/rustls/rustls-openssl-compat/actions/runs/14665104875/job/41157925135