### PR TITLE
tests/runner.rs: use pretty-assertions crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,6 +166,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,6 +404,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -510,6 +526,7 @@ dependencies = [
  "log",
  "openssl-probe",
  "openssl-sys",
+ "pretty_assertions",
  "rustls",
 ]
 
@@ -697,6 +714,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,6 @@ log = "0.4"
 openssl-probe = "0.1"
 openssl-sys = "0.9"
 rustls = "0.23.27"
+
+[dev-dependencies]
+pretty_assertions = "1"


### PR DESCRIPTION
The workflow here involves looking for differences in output from the test programs between us and openssl.  That is not very friendly because rust's default Debug format escapes newlines.  Add a newtype for `Output` which doesn't do that.

This is before and after  for artificial test failures:

Before:
```

thread 'ciphers' panicked at tests/runner.rs:317:5:
assertion `left == right` failed
  left: Output { status: ExitStatus(unix_wait_status(0)), stdout: "Found for 0xc02b\nopenssl_id=0x0300c02b protocol_id=0x0000c02b auth=1047 kx=1038 bits=128 alg_bits=128\nname='ECDHE-ECDSA-AES128-GCM-SHA256' standard_name='TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256' version='TLSv1.2'\ndesc='ECDHE-ECDSA-AES128-GCM-SHA256  TLSv1.2 Kx=ECDH     Au=ECDSA Enc=AESGCM(128)            Mac=AEAD\n'\nFound for 0xc02c\nopenssl_id=0x0300c02c protocol_id=0x0000c02c auth=1047 kx=1038 bits=256 alg_bits=256\nname='ECDHE-ECDSA-AES256-GCM-SHA384' standard_name='TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384' version='TLSv1.2'\ndesc='ECDHE-ECDSA-AES256-GCM-SHA384  TLSv1.2 Kx=ECDH     Au=ECDSA Enc=AESGCM(256)            Mac=AEAD\n'\nFound for 0xcca9\nopenssl_id=0x0300cca9 protocol_id=0x0000cca9 auth=1047 kx=1038 bits=256 alg_bits=256\nname='ECDHE-ECDSA-CHACHA20-POLY1305' standard_name='TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256' version='TLSv1.2'\ndesc='ECDHE-ECDSA-CHACHA20-POLY1305  TLSv1.2 Kx=ECDH     Au=ECDSA Enc=CHACHA20/POLY1305(256) Mac=AEAD\n'\nFound for 0xc02f\nopenssl_id=0x0300c02f protocol_id=0x0000c02f auth=1046 kx=1038 bits=128 alg_bits=128\nname='ECDHE-RSA-AES128-GCM-SHA256' standard_name='TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256' version='TLSv1.2'\ndesc='ECDHE-RSA-AES128-GCM-SHA256    TLSv1.2 Kx=ECDH     Au=RSA   Enc=AESGCM(128)            Mac=AEAD\n'\nFound for 0xc030\nopenssl_id=0x0300c030 protocol_id=0x0000c030 auth=1046 kx=1038 bits=256 alg_bits=256\nname='ECDHE-RSA-AES256-GCM-SHA384' standard_name='TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384' version='TLSv1.2'\ndesc='ECDHE-RSA-AES256-GCM-SHA384    TLSv1.2 Kx=ECDH     Au=RSA   Enc=AESGCM(256)            Mac=AEAD\n'\nFound for 0xcca8\nopenssl_id=0x0300cca8 protocol_id=0x0000cca8 auth=1046 kx=1038 bits=256 alg_bits=256\nname='ECDHE-RSA-CHACHA20-POLY1305' standard_name='TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256' version='TLSv1.2'\ndesc='ECDHE-RSA-CHACHA20-POLY1305    TLSv1.2 Kx=ECDH     Au=RSA   Enc=CHACHA20/POLY1305(256) Mac=AEAD\n'\nFound for 0x1301\nopenssl_id=0x03001301 protocol_id=0x00001301 auth=1064 kx=1063 bits=128 alg_bits=128\nname='TLS_AES_128_GCM_SHA256' standard_name='TLS_AES_128_GCM_SHA256' version='TLSv1.3'\ndesc='TLS_AES_128_GCM_SHA256         TLSv1.3 Kx=any      Au=any   Enc=AESGCM(128)            Mac=AEAD\n'\nFound for 0x1302\nopenssl_id=0x03001302 protocol_id=0x00001302 auth=1064 kx=1063 bits=256 alg_bits=256\nname='TLS_AES_256_GCM_SHA384' standard_name='TLS_AES_256_GCM_SHA384' version='TLSv1.3'\ndesc='TLS_AES_256_GCM_SHA384         TLSv1.3 Kx=any      Au=any   Enc=AESGCM(256)            Mac=AEAD\n'\nFound for 0x1303\nopenssl_id=0x03001303 protocol_id=0x00001303 auth=1064 kx=1063 bits=256 alg_bits=256\nname='TLS_CHACHA20_POLY1305_SHA256' standard_name='TLS_CHACHA20_POLY1305_SHA256' version='TLSv1.3'\ndesc='TLS_CHACHA20_POLY1305_SHA256   TLSv1.3 Kx=any      Au=any   Enc=CHACHA20/POLY1305(256) Mac=AEAD\n'\nopenssl_id=undef protocol_id=undef auth=undef kx=undef bits=0 alg_bits=-1\nname='(NONE)' standard_name='(NONE)' version='(NONE)'\ndesc=undef\n", stderr: "" }
 right: Output { status: ExitStatus(unix_wait_status(0)), stdout: "Found for 0xc02b\nopenssl_id=0x0300c02b protocol_id=0x0000c02b auth=1047 kx=9999 bits=128 alg_bits=128\nname='ECDHE-ECDSA-AES128-GCM-SHA256' standard_name='TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256' version='TLSv1.2'\ndesc='ECDHE-ECDSA-AES128-GCM-SHA256  TLSv1.2 Kx=ECDH     Au=ECDSA Enc=AESGCM(128)            Mac=AEAD\n'\nFound for 0xc02c\nopenssl_id=0x0300c02c protocol_id=0x0000c02c auth=1047 kx=9999 bits=256 alg_bits=256\nname='ECDHE-ECDSA-AES256-GCM-SHA384' standard_name='TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384' version='TLSv1.2'\ndesc='ECDHE-ECDSA-AES256-GCM-SHA384  TLSv1.2 Kx=ECDH     Au=ECDSA Enc=AESGCM(256)            Mac=AEAD\n'\nFound for 0xcca9\nopenssl_id=0x0300cca9 protocol_id=0x0000cca9 auth=1047 kx=9999 bits=256 alg_bits=256\nname='ECDHE-ECDSA-CHACHA20-POLY1305' standard_name='TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256' version='TLSv1.2'\ndesc='ECDHE-ECDSA-CHACHA20-POLY1305  TLSv1.2 Kx=ECDH     Au=ECDSA Enc=CHACHA20/POLY1305(256) Mac=AEAD\n'\nFound for 0xc02f\nopenssl_id=0x0300c02f protocol_id=0x0000c02f auth=1046 kx=9999 bits=128 alg_bits=128\nname='ECDHE-RSA-AES128-GCM-SHA256' standard_name='TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256' version='TLSv1.2'\ndesc='ECDHE-RSA-AES128-GCM-SHA256    TLSv1.2 Kx=ECDH     Au=RSA   Enc=AESGCM(128)            Mac=AEAD\n'\nFound for 0xc030\nopenssl_id=0x0300c030 protocol_id=0x0000c030 auth=1046 kx=9999 bits=256 alg_bits=256\nname='ECDHE-RSA-AES256-GCM-SHA384' standard_name='TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384' version='TLSv1.2'\ndesc='ECDHE-RSA-AES256-GCM-SHA384    TLSv1.2 Kx=ECDH     Au=RSA   Enc=AESGCM(256)            Mac=AEAD\n'\nFound for 0xcca8\nopenssl_id=0x0300cca8 protocol_id=0x0000cca8 auth=1046 kx=9999 bits=256 alg_bits=256\nname='ECDHE-RSA-CHACHA20-POLY1305' standard_name='TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256' version='TLSv1.2'\ndesc='ECDHE-RSA-CHACHA20-POLY1305    TLSv1.2 Kx=ECDH     Au=RSA   Enc=CHACHA20/POLY1305(256) Mac=AEAD\n'\nFound for 0x1301\nopenssl_id=0x03001301 protocol_id=0x00001301 auth=1064 kx=1063 bits=128 alg_bits=128\nname='TLS_AES_128_GCM_SHA256' standard_name='TLS_AES_128_GCM_SHA256' version='TLSv1.3'\ndesc='TLS_AES_128_GCM_SHA256         TLSv1.3 Kx=any      Au=any   Enc=AESGCM(128)            Mac=AEAD\n'\nFound for 0x1302\nopenssl_id=0x03001302 protocol_id=0x00001302 auth=1064 kx=1063 bits=256 alg_bits=256\nname='TLS_AES_256_GCM_SHA384' standard_name='TLS_AES_256_GCM_SHA384' version='TLSv1.3'\ndesc='TLS_AES_256_GCM_SHA384         TLSv1.3 Kx=any      Au=any   Enc=AESGCM(256)            Mac=AEAD\n'\nFound for 0x1303\nopenssl_id=0x03001303 protocol_id=0x00001303 auth=1064 kx=1063 bits=256 alg_bits=256\nname='TLS_CHACHA20_POLY1305_SHA256' standard_name='TLS_CHACHA20_POLY1305_SHA256' version='TLSv1.3'\ndesc='TLS_CHACHA20_POLY1305_SHA256   TLSv1.3 Kx=any      Au=any   Enc=CHACHA20/POLY1305(256) Mac=AEAD\n'\nopenssl_id=undef protocol_id=undef auth=undef kx=undef bits=0 alg_bits=-1\nname='(NONE)' standard_name='(NONE)' version='(NONE)'\ndesc=undef\n", stderr: "" }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

After:
```
thread 'ciphers' panicked at tests/runner.rs:319:5:
assertion failed: `(left == right)`

Diff < left / right > :
 Output {
     status: ExitStatus(
         unix_wait_status(
             0,
         ),
     ),
     stdout: "<follows>",
     stderr: "<follows>",
 }
 stdout => Found for 0xc02b
<stdout => openssl_id=0x0300c02b protocol_id=0x0000c02b auth=1047 kx=1038 bits=128 alg_bits=128
>stdout => openssl_id=0x0300c02b protocol_id=0x0000c02b auth=1047 kx=9999 bits=128 alg_bits=128
 stdout => name='ECDHE-ECDSA-AES128-GCM-SHA256' standard_name='TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256' version='TLSv1.2'
 stdout => desc='ECDHE-ECDSA-AES128-GCM-SHA256  TLSv1.2 Kx=ECDH     Au=ECDSA Enc=AESGCM(128)            Mac=AEAD
 stdout => '
 stdout => Found for 0xc02c
<stdout => openssl_id=0x0300c02c protocol_id=0x0000c02c auth=1047 kx=1038 bits=256 alg_bits=256
>stdout => openssl_id=0x0300c02c protocol_id=0x0000c02c auth=1047 kx=9999 bits=256 alg_bits=256
 stdout => name='ECDHE-ECDSA-AES256-GCM-SHA384' standard_name='TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384' version='TLSv1.2'
 stdout => desc='ECDHE-ECDSA-AES256-GCM-SHA384  TLSv1.2 Kx=ECDH     Au=ECDSA Enc=AESGCM(256)            Mac=AEAD
 stdout => '
 stdout => Found for 0xcca9
<stdout => openssl_id=0x0300cca9 protocol_id=0x0000cca9 auth=1047 kx=1038 bits=256 alg_bits=256
>stdout => openssl_id=0x0300cca9 protocol_id=0x0000cca9 auth=1047 kx=9999 bits=256 alg_bits=256
 stdout => name='ECDHE-ECDSA-CHACHA20-POLY1305' standard_name='TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256' version='TLSv1.2'
 stdout => desc='ECDHE-ECDSA-CHACHA20-POLY1305  TLSv1.2 Kx=ECDH     Au=ECDSA Enc=CHACHA20/POLY1305(256) Mac=AEAD
 stdout => '
 stdout => Found for 0xc02f
<stdout => openssl_id=0x0300c02f protocol_id=0x0000c02f auth=1046 kx=1038 bits=128 alg_bits=128
>stdout => openssl_id=0x0300c02f protocol_id=0x0000c02f auth=1046 kx=9999 bits=128 alg_bits=128
 stdout => name='ECDHE-RSA-AES128-GCM-SHA256' standard_name='TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256' version='TLSv1.2'
 stdout => desc='ECDHE-RSA-AES128-GCM-SHA256    TLSv1.2 Kx=ECDH     Au=RSA   Enc=AESGCM(128)            Mac=AEAD
 stdout => '
 stdout => Found for 0xc030
<stdout => openssl_id=0x0300c030 protocol_id=0x0000c030 auth=1046 kx=1038 bits=256 alg_bits=256
>stdout => openssl_id=0x0300c030 protocol_id=0x0000c030 auth=1046 kx=9999 bits=256 alg_bits=256
 stdout => name='ECDHE-RSA-AES256-GCM-SHA384' standard_name='TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384' version='TLSv1.2'
 stdout => desc='ECDHE-RSA-AES256-GCM-SHA384    TLSv1.2 Kx=ECDH     Au=RSA   Enc=AESGCM(256)            Mac=AEAD
 stdout => '
 stdout => Found for 0xcca8
<stdout => openssl_id=0x0300cca8 protocol_id=0x0000cca8 auth=1046 kx=1038 bits=256 alg_bits=256
>stdout => openssl_id=0x0300cca8 protocol_id=0x0000cca8 auth=1046 kx=9999 bits=256 alg_bits=256
 stdout => name='ECDHE-RSA-CHACHA20-POLY1305' standard_name='TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256' version='TLSv1.2'
 stdout => desc='ECDHE-RSA-CHACHA20-POLY1305    TLSv1.2 Kx=ECDH     Au=RSA   Enc=CHACHA20/POLY1305(256) Mac=AEAD
 stdout => '
 stdout => Found for 0x1301
 stdout => openssl_id=0x03001301 protocol_id=0x00001301 auth=1064 kx=1063 bits=128 alg_bits=128
 stdout => name='TLS_AES_128_GCM_SHA256' standard_name='TLS_AES_128_GCM_SHA256' version='TLSv1.3'
 stdout => desc='TLS_AES_128_GCM_SHA256         TLSv1.3 Kx=any      Au=any   Enc=AESGCM(128)            Mac=AEAD
 stdout => '
 stdout => Found for 0x1302
 stdout => openssl_id=0x03001302 protocol_id=0x00001302 auth=1064 kx=1063 bits=256 alg_bits=256
 stdout => name='TLS_AES_256_GCM_SHA384' standard_name='TLS_AES_256_GCM_SHA384' version='TLSv1.3'
 stdout => desc='TLS_AES_256_GCM_SHA384         TLSv1.3 Kx=any      Au=any   Enc=AESGCM(256)            Mac=AEAD
 stdout => '
 stdout => Found for 0x1303
 stdout => openssl_id=0x03001303 protocol_id=0x00001303 auth=1064 kx=1063 bits=256 alg_bits=256
 stdout => name='TLS_CHACHA20_POLY1305_SHA256' standard_name='TLS_CHACHA20_POLY1305_SHA256' version='TLSv1.3'
 stdout => desc='TLS_CHACHA20_POLY1305_SHA256   TLSv1.3 Kx=any      Au=any   Enc=CHACHA20/POLY1305(256) Mac=AEAD
 stdout => '
 stdout => openssl_id=undef protocol_id=undef auth=undef kx=undef bits=0 alg_bits=-1
 stdout => name='(NONE)' standard_name='(NONE)' version='(NONE)'
 stdout => desc=undef



note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

It's also colour highlighted -- 

![image](https://github.com/user-attachments/assets/f9a3faf5-d441-49db-9e31-28d657d73f72)
