### PR TITLE
Support trace logging of function entry/exit

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,7 @@ mod x509;
 ///
 /// # Lifetime
 /// Functions that return SSL_METHOD, like `TLS_method()`, give static-lifetime pointers.
+#[derive(Debug)]
 pub struct SslMethod {
     client_versions: &'static [&'static SupportedProtocolVersion],
     server_versions: &'static [&'static SupportedProtocolVersion],


### PR DESCRIPTION
This enables debug-mode trace-level debug for all function calls/returns:

```
[2025-06-06T14:07:30Z TRACE ssl::entry] -> SSL_version(0x51c000000890,)
[2025-06-06T14:07:30Z TRACE ssl::entry] <- SSL_version [772]
```