### PR TITLE
docs: mention lld requirement as it exists today

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ $ sudo service nginx restart
 `rustls-libssl-nginx enable` installs a systemd drop-in in `/etc/systemd/system/nginx.service.d/`.
 `rustls-libssl-nginx disable` undoes that.
 
+## Building from source
+
+In addition to Rust 1.77+ you will require `lld` to build `rustls-libssl` from
+source. At the time of writing the default linker (`ld`) doesn't offer
+sufficient `--version-script` support and `lld` must be available for the
+project `build.rs` script to use.
+
 # Changelog
 The detailed list of changes in each release can be found at
 https://github.com/rustls/rustls-openssl-compat/releases.


### PR DESCRIPTION
We don't have a `CONTRIBUTING.md` for this repo, so this branch tucks a brief mention of the `lld` requirement into `README.md`. Given the stage this project is in I'm not sure it's worth trying to do any more advanced contortions to detect the absence of `lld` in `build.rs` to emit a diagnostic message, but I could take a look at doing that if folks disagree.

Resolves https://github.com/rustls/rustls-openssl-compat/issues/81