### PR TITLE
Make `PartialOrd` impls more idiomatic

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -384,7 +384,7 @@ impl SslSession {
 
 impl PartialOrd<Self> for SslSession {
     fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
-        Some(self.id.cmp(&other.id))
+        Some(self.cmp(other))
     }
 }
 

--- a/src/not_thread_safe.rs
+++ b/src/not_thread_safe.rs
@@ -50,7 +50,7 @@ impl<T: Ord + PartialOrd> Ord for NotThreadSafe<T> {
 
 impl<T: PartialOrd<T> + Ord> PartialOrd for NotThreadSafe<T> {
     fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
-        Some(self.get().cmp(other.get()))
+        Some(self.cmp(other))
     }
 }
 


### PR DESCRIPTION
Fixes nightly clippy `non_canonical_partial_ord_impl` lint.