### PR TITLE
Fix flickery test involving example.com

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -146,8 +146,7 @@ pub fn named_group_to_nid(group: NamedGroup) -> Option<c_int> {
         FFDHE4096 => Some(NID_FFDHE4096),
         FFDHE6144 => Some(NID_FFDHE6144),
         FFDHE8192 => Some(NID_FFDHE8192),
-        Unknown(id) => Some(TLSEXT_NID_UNKNOWN | id as c_int),
-        _ => None,
+        other => Some(TLSEXT_NID_UNKNOWN | u16::from(other) as c_int),
     }
 }
 

--- a/tests/runner.rs
+++ b/tests/runner.rs
@@ -239,7 +239,7 @@ fn client_real_world() {
     let openssl_output = Command::new("tests/maybe-valgrind.sh")
         .env("LD_LIBRARY_PATH", "")
         .env("NO_ECHO", "1")
-        .args(["target/client", "example.com", "443", "default"])
+        .args(["target/client", "jbp.io", "443", "default"])
         .stdout(Stdio::piped())
         .output()
         .map(print_output)
@@ -247,7 +247,7 @@ fn client_real_world() {
 
     let rustls_output = Command::new("tests/maybe-valgrind.sh")
         .env("NO_ECHO", "1")
-        .args(["target/client", "example.com", "443", "default"])
+        .args(["target/client", "jbp.io", "443", "default"])
         .stdout(Stdio::piped())
         .output()
         .map(print_output)


### PR DESCRIPTION
Aiming to fix issues like https://github.com/rustls/rustls-openssl-compat/actions/runs/16417778664/job/46387897459