### PR TITLE
Rework key and certificate configuration APIs

### DIFF
--- a/src/conf.rs
+++ b/src/conf.rs
@@ -180,7 +180,7 @@ impl SslConfigCtx {
             State::ApplyingToCtx(ctx) => {
                 // the "Certificate" command after `SSL_CONF_CTX_set_ssl_ctx` is documented as using
                 // `SSL_CTX_use_certificate_chain_file`.
-                ctx.get_mut().stage_certificate_chain(cert_chain);
+                ctx.get_mut().stage_certificate_chain(cert_chain)?;
                 ActionResult::Applied
             }
             State::ApplyingToSsl(_) => {

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -180,7 +180,7 @@ impl SslConfigCtx {
             State::ApplyingToCtx(ctx) => {
                 // the "Certificate" command after `SSL_CONF_CTX_set_ssl_ctx` is documented as using
                 // `SSL_CTX_use_certificate_chain_file`.
-                ctx.get_mut().stage_certificate_chain(cert_chain)?;
+                ctx.get_mut().stage_certificate_full_chain(cert_chain)?;
                 ActionResult::Applied
             }
             State::ApplyingToSsl(_) => {

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -283,7 +283,7 @@ entry! {
                     }
                 };
 
-                match ctx.get_mut().stage_certificate_chain(chain) {
+                match ctx.get_mut().stage_certificate_chain_tail(chain) {
                     Err(e) => e.raise().into(),
                     Ok(()) => C_INT_SUCCESS as i64,
                 }
@@ -481,7 +481,7 @@ entry! {
             Err(err) => return err.raise().into(),
         };
 
-        match ctx.get_mut().stage_certificate_chain(chain) {
+        match ctx.get_mut().stage_certificate_full_chain(chain) {
             Ok(()) => C_INT_SUCCESS,
             Err(e) => e.raise().into(),
         }
@@ -964,7 +964,7 @@ entry! {
                     }
                 };
 
-                match ssl.get_mut().stage_certificate_chain(chain) {
+                match ssl.get_mut().stage_certificate_chain_tail(chain) {
                     Ok(()) => C_INT_SUCCESS as i64,
                     Err(e) => e.raise().into(),
                 }

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -283,8 +283,10 @@ entry! {
                     }
                 };
 
-                ctx.get_mut().stage_certificate_chain(chain);
-                C_INT_SUCCESS as i64
+                match ctx.get_mut().stage_certificate_chain(chain) {
+                    Err(e) => e.raise().into(),
+                    Ok(()) => C_INT_SUCCESS as i64,
+                }
             }
             Ok(SslCtrl::SetTlsExtServerNameArg) => {
                 ctx.get_mut().set_servername_callback_context(parg);
@@ -479,8 +481,10 @@ entry! {
             Err(err) => return err.raise().into(),
         };
 
-        ctx.get_mut().stage_certificate_chain(chain);
-        C_INT_SUCCESS
+        match ctx.get_mut().stage_certificate_chain(chain) {
+            Ok(()) => C_INT_SUCCESS,
+            Err(e) => e.raise().into(),
+        }
     }
 }
 
@@ -523,8 +527,10 @@ entry! {
         let x509 = OwnedX509::new_incref(x);
         let ee = CertificateDer::from(x509.der_bytes());
 
-        ctx.get_mut().stage_certificate_end_entity(ee);
-        C_INT_SUCCESS
+        match ctx.get_mut().stage_certificate_end_entity(ee) {
+            Ok(()) => C_INT_SUCCESS,
+            Err(e) => e.raise().into(),
+        }
     }
 }
 
@@ -958,8 +964,10 @@ entry! {
                     }
                 };
 
-                ssl.get_mut().stage_certificate_chain(chain);
-                C_INT_SUCCESS as i64
+                match ssl.get_mut().stage_certificate_chain(chain) {
+                    Ok(()) => C_INT_SUCCESS as i64,
+                    Err(e) => e.raise().into(),
+                }
             }
             Ok(SslCtrl::GetNegotiatedGroup) => ssl
                 .get()
@@ -1448,8 +1456,10 @@ entry! {
         let x509 = OwnedX509::new_incref(x);
         let ee = CertificateDer::from(x509.der_bytes());
 
-        ssl.get_mut().stage_certificate_end_entity(ee);
-        C_INT_SUCCESS
+        match ssl.get_mut().stage_certificate_end_entity(ee) {
+            Ok(()) => C_INT_SUCCESS,
+            Err(e) => e.raise().into(),
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -685,11 +685,18 @@ impl SslContext {
         self.auth_keys.stage_certificate_end_entity(end)
     }
 
-    fn stage_certificate_chain(
+    fn stage_certificate_full_chain(
         &mut self,
         chain: Vec<CertificateDer<'static>>,
     ) -> Result<(), error::Error> {
-        self.auth_keys.stage_certificate_chain(chain)
+        self.auth_keys.stage_certificate_full_chain(chain)
+    }
+
+    fn stage_certificate_chain_tail(
+        &mut self,
+        chain: Vec<CertificateDer<'static>>,
+    ) -> Result<(), error::Error> {
+        self.auth_keys.stage_certificate_chain_tail(chain)
     }
 
     fn commit_private_key(&mut self, key: evp_pkey::EvpPkey) -> Result<(), error::Error> {
@@ -946,11 +953,11 @@ impl Ssl {
         self.auth_keys.stage_certificate_end_entity(end)
     }
 
-    fn stage_certificate_chain(
+    fn stage_certificate_chain_tail(
         &mut self,
         chain: Vec<CertificateDer<'static>>,
     ) -> Result<(), error::Error> {
-        self.auth_keys.stage_certificate_chain(chain)
+        self.auth_keys.stage_certificate_chain_tail(chain)
     }
 
     fn commit_private_key(&mut self, key: evp_pkey::EvpPkey) -> Result<(), error::Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -678,11 +678,17 @@ impl SslContext {
         self.cert_callback = callbacks::CertCallbackConfig { cb, context };
     }
 
-    fn stage_certificate_end_entity(&mut self, end: CertificateDer<'static>) {
+    fn stage_certificate_end_entity(
+        &mut self,
+        end: CertificateDer<'static>,
+    ) -> Result<(), error::Error> {
         self.auth_keys.stage_certificate_end_entity(end)
     }
 
-    fn stage_certificate_chain(&mut self, chain: Vec<CertificateDer<'static>>) {
+    fn stage_certificate_chain(
+        &mut self,
+        chain: Vec<CertificateDer<'static>>,
+    ) -> Result<(), error::Error> {
         self.auth_keys.stage_certificate_chain(chain)
     }
 
@@ -933,11 +939,17 @@ impl Ssl {
         self.mode == ConnMode::Server
     }
 
-    fn stage_certificate_end_entity(&mut self, end: CertificateDer<'static>) {
+    fn stage_certificate_end_entity(
+        &mut self,
+        end: CertificateDer<'static>,
+    ) -> Result<(), error::Error> {
         self.auth_keys.stage_certificate_end_entity(end)
     }
 
-    fn stage_certificate_chain(&mut self, chain: Vec<CertificateDer<'static>>) {
+    fn stage_certificate_chain(
+        &mut self,
+        chain: Vec<CertificateDer<'static>>,
+    ) -> Result<(), error::Error> {
         self.auth_keys.stage_certificate_chain(chain)
     }
 

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -34,12 +34,20 @@ pub struct CertifiedKeySet {
 }
 
 impl CertifiedKeySet {
-    pub fn stage_certificate_chain(&mut self, chain: Vec<CertificateDer<'static>>) {
+    pub fn stage_certificate_chain(
+        &mut self,
+        chain: Vec<CertificateDer<'static>>,
+    ) -> Result<(), error::Error> {
         self.pending_cert_chain = Some(chain);
+        Ok(())
     }
 
-    pub fn stage_certificate_end_entity(&mut self, end: CertificateDer<'static>) {
+    pub fn stage_certificate_end_entity(
+        &mut self,
+        end: CertificateDer<'static>,
+    ) -> Result<(), error::Error> {
         self.pending_cert_end_entity = Some(end);
+        Ok(())
     }
 
     pub fn commit_private_key(&mut self, key: EvpPkey) -> Result<(), error::Error> {

--- a/src/sign.rs
+++ b/src/sign.rs
@@ -34,7 +34,27 @@ pub struct CertifiedKeySet {
 }
 
 impl CertifiedKeySet {
-    pub fn stage_certificate_chain(
+    /// Set the entirety of the current certificate chain to `chain`.
+    ///
+    /// `chain[0]` is the end-entity cert.
+    pub fn stage_certificate_full_chain(
+        &mut self,
+        mut chain: Vec<CertificateDer<'static>>,
+    ) -> Result<(), error::Error> {
+        match chain.is_empty() {
+            false => {
+                self.stage_certificate_end_entity(chain.remove(0))?;
+                self.stage_certificate_chain_tail(chain)
+            }
+            true => Err(error::Error::bad_data("empty certificate full chain")),
+        }
+    }
+
+    /// Set the "bottom part" of the current certificate chain to `chain`.
+    ///
+    /// This does not contain the end-entity certificate.  That must be provided separately
+    /// with `stage_certificate_end_entity()`.
+    pub fn stage_certificate_chain_tail(
         &mut self,
         chain: Vec<CertificateDer<'static>>,
     ) -> Result<(), error::Error> {

--- a/tests/runner.rs
+++ b/tests/runner.rs
@@ -704,14 +704,18 @@ fn nginx_1_24() {
         35
     );
     // TLS 1.3 to the TLS 1.3 only port should succeed.
-    // The RSA CA cert should allow verification to succeed, showing the overrides of
+    // The ED25519 CA cert should allow verification to succeed, showing the overrides of
     // the ED25519 ssl_certificate/ssl_certificate_key directives worked.
+    //
+    // Note that curl+openssl by default prefers ECDSA/ED25519 to RSA, but this
+    // port is capable of selecting either.  We could test for both if/when we have
+    // curl 8.14.0 or later, using the new `--sigalgs` parameter.
     assert_eq!(
         Command::new("curl")
             .env("LD_LIBRARY_PATH", "")
             .args([
                 "--cacert",
-                "test-ca/rsa/ca.cert",
+                "test-ca/ed25519/ca.cert",
                 "--tlsv1.3",
                 "https://localhost:8447/ssl-agreed"
             ])
@@ -728,7 +732,7 @@ fn nginx_1_24() {
             .env("LD_LIBRARY_PATH", "")
             .args([
                 "--cacert",
-                "test-ca/rsa/ca.cert",
+                "test-ca/ed25519/ca.cert",
                 "--tlsv1.3",
                 "https://localhost:8448/ssl-agreed"
             ])


### PR DESCRIPTION
`haproxy` configures its cert/key using this order:

- `SSL_CTX_use_PrivateKey`
- `SSL_CTX_use_certificate`
- `SSL_CTX_set1_chain`

Which is contrary to the OpenSSL documentation, which says:

> To change a [certificate/private-key] pair, the new certificate needs to be set first with
> SSL_use_certificate() or SSL_CTX_use_certificate() before setting the private key with
> SSL_CTX_use_PrivateKey() or SSL_use_PrivateKey().

Our previous implementation followed this ordering. This one doesn't.

This PR also introduces basic certificate switching, allowing a server to have ECDSA, ED25519 and RSA keys simultaneously.

re #62